### PR TITLE
Auto-generate runtime API docs from types.d.ts

### DIFF
--- a/docs/runtime-api/command-bar.md
+++ b/docs/runtime-api/command-bar.md
@@ -18,19 +18,14 @@ Let's press `Ctrl + K` to open the Command Bar.
 
 To add your custom actions, please use the APIs below.
 
-## CommandBar.addAction
+## CommandBar.addAction(action)
 
 <Badge type="info" text="function" />
 <Badge type="tip" text="since v1.1.0" />
 
-```ts
-function addAction(action: Action): void
-```
-
 Add a new action item to the Command Bar. It will automatically update even when showing.
 
 #### Params
-
 - `action`: An object that describes action information with these properties
 
 ```ts
@@ -46,25 +41,17 @@ interface Action {
 }
 ```
 
-## CommandBar.show
+## CommandBar.show()
 
 <Badge type="info" text="function" />
 <Badge type="tip" text="since v1.1.0" />
-
-```ts
-function show(): void
-```
 
 Show the Command Bar programmatically if it was hidden.
 
-## CommandBar.update
+## CommandBar.update()
 
 <Badge type="info" text="function" />
 <Badge type="tip" text="since v1.1.0" />
-
-```ts
-function update(): void
-```
 
 Manually trigger the Command Bar to update its items.
 Only use this function if your added actions are not updating.

--- a/docs/runtime-api/data-store.md
+++ b/docs/runtime-api/data-store.md
@@ -1,7 +1,41 @@
-# DataStore namespace
+# DataStore
 
-League Client does not store user data on disk, similar to incognito mode in web
-browsers. This namespace helps you to store user data on disk.
+League Client does not store user data on disk, similar to incognito mode in web browsers. This namespace helps you to store user data on disk.
+
+## DataStore.has(key)
+
+<Badge type="info" text="function" />
+<Badge type="tip" text="since v1.0.1" />
+
+This function returns a boolean indicating whether data with the specified key exists or not.
+
+Example:
+
+```js
+console.log(DataStore.has('my_num'))
+console.log(DataStore.has('key-does-not-exist'))
+```
+
+## DataStore.get(key, fallback?)
+
+<Badge type="info" text="function" />
+<Badge type="tip" text="since v1.0.1" />
+
+Retrieve your stored data with a given key. If the key does not exist, it will return `undefined`.
+
+Since **v1.0.5**, you can set fallback value for non-existent keys.
+
+Example:
+
+```js
+console.log(DataStore.get('my_str'))
+// some string
+console.log(DataStore.get('key-does-not-exist'))
+// undefined
+
+console.log(DataStore.get('key-does-not-exist', 1000))
+// 1000
+```
 
 ## DataStore.set(key, value)
 
@@ -11,14 +45,11 @@ browsers. This namespace helps you to store user data on disk.
 Call this function to store your data with a given key.
 
 Parameters:
-
 - `key` (required) Keys should be string or number.
-- `value` (required) Value may be string, number, boolean, null or collection
-  like array and object. Actually, it will be stored as JSON format, so any
-  value like function and runtime object are ignored.
+- `value` (required) Value may be string, number, boolean, null or collection like array and object. Actually, it will be stored as JSON format, so any value like function and runtime object are ignored.
 
 Returns:
-- A boolean value that indicates your key is valid and the data is stored successfully. 
+- A boolean value that indicates your key is valid and the data is stored successfully.
 
 Example:
 
@@ -31,56 +62,16 @@ DataStore.set('my_str', my_str)
 
 ::: tip Unique keys
 
-You should use unique names for keys, do not use common names, e.g
-`access_token`, `is_logged`, etc. Other plugins can override your data, you can
-add prefix to your keys.
+You should use unique names for keys, do not use common names, e.g `access_token`, `is_logged`, etc. Other plugins can override your data, you can add prefix to your keys.
 
 :::
-
-## DataStore.get(key, fallback?)
-
-<Badge type="info" text="function" />
-<Badge type="tip" text="since v1.0.1" />
-
-Retrieve your stored data with a given key. If the key does not exist, it will
-return `undefined`.
-
-Example:
-
-```js
-console.log(DataStore.get('my_str'))
-// some string
-console.log(DataStore.get('key-does-not-exist'))
-// undefined
-```
-
-Since **v1.0.5**, you can set fallback value for non-existent keys.
-
-```js
-console.log(DataStore.get('key-does-not-exist', 1000))
-// 1000
-```
-
-## DataStore.has(key)
-
-<Badge type="info" text="function" />
-<Badge type="tip" text="since v1.0.1" />
-
-This function returns a boolean indicating whether data with the specified key
-exists or not.
-
-```js
-console.log(DataStore.has('my_num'))
-console.log(DataStore.has('key-does-not-exist'))
-```
 
 ## DataStore.remove(key)
 
 <Badge type="info" text="function" />
 <Badge type="tip" text="since v1.0.1" />
 
-This function removes the specified data from storage by key, returns true if
-the existing key-value pair has been removed.
+This function removes the specified data from storage by key, returns true if the existing key-value pair has been removed.
 
 Example:
 

--- a/docs/runtime-api/effect.md
+++ b/docs/runtime-api/effect.md
@@ -6,41 +6,19 @@ This namespace supports changing window transparency/translucent effect.
 
 ![](https://user-images.githubusercontent.com/38210249/216951830-b3bb3ce3-7a5f-4e60-8a67-33d0bce799cf.png)
 
-## Effect.current
-
-<Badge type="info" text="string" />
-<Badge type="tip" text="since v1.0.1" />
-
-A read-only property that returns the currently applied effect or `null` if
-no effect has been applied.
-
-Available effects: `mica`, `acrylic`, `unified` and `blurbehind`.
-
-Example:
-
-```js
-console.log(Effect.current)
-// mica
-```
-
-## Effect.apply(name, options?)
+## Effect.apply()
 
 <Badge type="info" text="function" />
-<Badge type="success" text="since v1.0.1" />
+<Badge type="tip" text="since v1.0.1" />
 
-A function that takes the name of the desired effect name and an optional
-object.<br> It returns a boolean indicating whether the effect was successfully
-applied or not.
+A function that takes the name of the desired effect name and an optional object.
+It returns a boolean indicating whether the effect was successfully applied or not.
 
 Parameters:
-
 - `name` [required] These effect names above to be applied, in string.
+- `options` [optional] Additional options for the effect, `acrylic`, `unified` and `blurbehind` could have tint color, but `mica` will ignore this options.
 
-- `options` [optional] Additional options for the effect, `acrylic`, `unified`
-  and `blurbehind` could have tint color, but `mica` will ignore this options.
-
-This function returns `false` if the effect could not be applied, see the
-[System compatibility](#system-compatibility) below.
+This function returns `false` if the effect could not be applied, see the [System compatibility](#system-compatibility) below.
 
 Example:
 
@@ -57,23 +35,19 @@ Effect.apply('mica')
 
 ::: info
 
-Tint colors must be in CSS hex color format, e.g. #RGB, #RGBA, #RRGGBB,
-#RRGGBBAA.
+Tint colors must be in CSS hex color format, e.g. #RGB, #RGBA, #RRGGBB, #RRGGBBAA.
 
 To see transparency effect correctly, you should remove all lowest backgrounds.
 
 :::
-
-![](https://user-images.githubusercontent.com/38210249/216951865-bb9c6676-58ec-4c81-ad96-67e94e91ac22.png)
 
 ## Effect.clear()
 
 <Badge type="info" text="function" />
 <Badge type="tip" text="since v1.0.1" />
 
-A function that clears any currently applied effect, then the Client background
-will be black.<br> Using `Effect.current` after clearing will give you
-`undefined`.
+A function that clears any currently applied effect, then the Client background will be black.
+Using `Effect.current` after clearing will give you `undefined`.
 
 Example:
 
@@ -81,6 +55,15 @@ Example:
 // just clear applied effect, even if nothing applied
 Effect.clear()
 ```
+
+## Effect.setTheme(theme)
+
+<Badge type="info" text="function" />
+<Badge type="tip" text="since v1.0.1" />
+
+Set the window theme to light or dark.
+
+![](https://user-images.githubusercontent.com/38210249/216951865-bb9c6676-58ec-4c81-ad96-67e94e91ac22.png)
 
 ## System compatibility
 

--- a/docs/runtime-api/effect.md
+++ b/docs/runtime-api/effect.md
@@ -59,7 +59,7 @@ Effect.clear()
 ## Effect.setTheme(theme)
 
 <Badge type="info" text="function" />
-<Badge type="tip" text="since v1.0.1" />
+<Badge type="tip" text="since v1.1.0" />
 
 Set the window theme to light or dark.
 

--- a/docs/runtime-api/index.md
+++ b/docs/runtime-api/index.md
@@ -6,7 +6,7 @@ runtime.
 ## window.openDevTools(remote?)
 
 <Badge type="info" text="function" />
-<Badge type="tip" text="since v0.3" />
+<Badge type="tip" text="since v0.1" />
 
 Call this function to open the built-in Chrome DevTools window.
 
@@ -20,7 +20,7 @@ window.openDevTools(true) // remote DevTools
 ## window.openPluginsFolder(subdir?)
 
 <Badge type="info" text="function" />
-<Badge type="tip" text="since v1.0" />
+<Badge type="tip" text="since v0.6" />
 
 Call this function to open the plugins folder in new File Explorer window.
 
@@ -76,7 +76,7 @@ window.getScriptPath()
 ## window.__llver
 
 <Badge type="info" text="string" />
-<Badge type="tip" text="since v0.6" />
+<Badge type="tip" text="since v1.0.1" />
 <Badge type="warning" text="deprecated" />
 
 This property returns the current version of Pengu Loader.

--- a/docs/runtime-api/index.md
+++ b/docs/runtime-api/index.md
@@ -17,21 +17,7 @@ window.openDevTools()     // built-in DevTools
 window.openDevTools(true) // remote DevTools
 ```
 
-## window.openAssetsFolder()
-
-<Badge type="info" text="function" />
-<Badge type="tip" text="since v0.6" />
-<Badge type="warning" text="deprecated" />
-
-Call this function to open the assets folder in new File Explorer window.
-
-Example:
-
-```js
-window.openAssetsFolder()
-```
-
-## window.openPluginsFolder(path?)
+## window.openPluginsFolder(subdir?)
 
 <Badge type="info" text="function" />
 <Badge type="tip" text="since v1.0" />

--- a/docs/runtime-api/pengu.md
+++ b/docs/runtime-api/pengu.md
@@ -1,4 +1,4 @@
-# Pengu namespace
+# Pengu
 
 This namespace provides information about current Pengu version and its settings.
 
@@ -8,6 +8,8 @@ This namespace provides information about current Pengu version and its settings
 <Badge type="tip" text="since v1.1.0" />
 
 A read-only property that returns the current version of Pengu Loader.
+
+Example:
 
 ```js
 console.log(Pengu.version)
@@ -21,6 +23,8 @@ console.log(Pengu.version)
 
 A boolean value that indicates the **Super Low Spec Mode** is enabled or not.
 
+Example:
+
 ```js
 console.log(Pengu.superPotato)
 // true
@@ -33,7 +37,24 @@ console.log(Pengu.superPotato)
 
 An array of plugin entries.
 
+Example:
+
 ```js
 console.log(Pengu.plugins)
 // [ '@default/index.js', 'your-plugin/index.js' ]
+```
+
+## Pengu.isMac
+
+<Badge type="info" text="boolean" />
+<Badge type="tip" text="since v1.1.0" />
+
+A boolean value that indicates whether the current platform is macOS.
+
+Example:
+
+```js
+if (Pengu.isMac) {
+  console.log('Running on macOS')
+}
 ```

--- a/docs/runtime-api/pengu.md
+++ b/docs/runtime-api/pengu.md
@@ -47,7 +47,7 @@ console.log(Pengu.plugins)
 ## Pengu.isMac
 
 <Badge type="info" text="boolean" />
-<Badge type="tip" text="since v1.1.0" />
+<Badge type="tip" text="since v1.1.2" />
 
 A boolean value that indicates whether the current platform is macOS.
 

--- a/docs/runtime-api/plugin-fs.md
+++ b/docs/runtime-api/plugin-fs.md
@@ -20,20 +20,18 @@ All paths passed into this API are relative to the root directory of your plugin
 
 <Badge type="info" text="function" />
 <Badge type="tip" text="since v1.1.0" />
+<Badge type="warning" text="deprecated" />
 
 Read a file in text mode.
 
 ### Params
-
 - `path` - The path of the file you want to access with respect to the plugin root directory.
 
 ### Return value
-
 A `Promise` of the content string on success.
-
 A `Promise` of `undefined` on failure.
 
-### Example
+Example:
 
 ```javascript
 PluginFS.read("./index.js").then( content => {
@@ -43,24 +41,23 @@ PluginFS.read("./index.js").then( content => {
 const content = await PluginFs.read("./README.md")
 ```
 
-## PluginFS.write(path,content,enableAppendMode?)
+## PluginFS.write(path, content, enableAppendMode?)
 
 <Badge type="info" text="function" />
 <Badge type="tip" text="since v1.1.0" />
+<Badge type="warning" text="deprecated" />
 
 Write to a file in text mode.
 
 ### Params
-
 - `path` - The path of the file you want to access with respect to the plugin root directory.
 - `content` - The content string you want to write into.
 - `enableAppendMode` - Append to file if set to `true` or overwrite file if `false`. This is `false` by default.
 
 ### Return value
-
 A `Promise` of a boolean result indicating success or failure.
 
-### Example
+Example:
 
 ```javascript
 // Create test.txt and write "Hello" into it
@@ -86,18 +83,17 @@ This API can create a file but can't create a file under a non-existing director
 
 <Badge type="info" text="function" />
 <Badge type="tip" text="since v1.1.0" />
+<Badge type="warning" text="deprecated" />
 
 Create directories recursively.
 
 ### Params
-
 `path` - The directory path you want to create with respect to the plugin root directory.
 
 ### Return Value
-
 A `Promise` of a boolean result indicating success or failure.
 
-### Example
+Example:
 
 ```javascript
 const bMkdir0 = await PluginFS.mkdir("utils")
@@ -111,27 +107,17 @@ const bMkdir3 = await PluginFS.mkdir("a\\b/")
 
 <Badge type="info" text="function" />
 <Badge type="tip" text="since v1.1.0" />
+<Badge type="warning" text="deprecated" />
 
 Get the status of a file.
 
 ### Params
-
 - `path` - The file path with respect to the plugin root directory.
 
 ### Return value
-
 A `Promise` of `FileStat` or `undefined` depending on success or failure.
 
-```typescript
-interface FileStat{
-  fileName: string
-  // 0 if isDir is true
-  length: number
-  isDir: boolean
-}
-```
-
-### Example
+Example:
 
 ```javascript
 const stat1 = await PluginFS.stat("a/b")
@@ -145,48 +131,36 @@ const stat2 = await PluginFS.stat("a/random.js")
 
 <Badge type="info" text="function" />
 <Badge type="tip" text="since v1.1.0" />
+<Badge type="warning" text="deprecated" />
 
 List files and directories under given path. 
 
 ### Params
-
 - `path` - The directory path with respect to the plugin root directory.
 
 ### Return value
-
 A `Promise` of `Array` of file name strings on success.
-
 A `Promise` of `undefined` on failure.
 
-## PluginFS.rm(path,recursively?)
+## PluginFS.rm(path, recursively?)
 
 <Badge type="info" text="function" />
 <Badge type="tip" text="since v1.1.0" />
-
-::: danger
-
-You should know what you are doing when using this.
-
-:::
+<Badge type="warning" text="deprecated" />
 
 Remove file/directories.
 
 Just like `rm` command in Unix-like systems.
 
 ### Params
-
 - `path` - The file/directory path with respect to the plugin root directory.
 - `recursively` - Delete all files/directories under the give path recursively. This is `false` by default.
 
 ### Return value
-
 A `Promise` of a `number` showing how many files and directories is deleted.
-
 When deleting with `recursively` set to `true`, the number value is sum of deleted `directories` and `files`.
 
-### Example
-
-You can only delete a non-empty directory with `recursively` set to `true`
+Example:
 
 ```javascript
 // 1
@@ -199,3 +173,9 @@ const bRm3 = await PluginFS.rm("./non-empty-dir")
 // bRm4 >= 1 with recursively set to true
 const bRm4 = await PluginFS.rm("./non-empty-dir",true)
 ```
+
+::: danger
+
+You should know what you are doing when using this.
+
+:::

--- a/docs/runtime-api/rcp.md
+++ b/docs/runtime-api/rcp.md
@@ -1,6 +1,4 @@
-# Riot Client Pugin hooks
-
-## General usage
+# rcp
 
 This object provides easy access and hook to the Riot Client Plugin (RCP) system.
 
@@ -26,9 +24,10 @@ const rcp = window.rcp
 Register a callback that will be triggered before the target plugin loads.
 
 ### Params
-
 - `name` - RCP name, should be prefixed with `rcp-`.
 - `callback` - A function will be triggered before the plugin loads.
+
+You can delay the plugin loads by blocking your async callback.
 
 Example:
 
@@ -36,11 +35,7 @@ Example:
 rcp.preInit('rcp-name', (context) => {
   // do something
 })
-```
 
-You can delay the plugin loads by blocking your async callback:
-
-```js
 rcp.preInit('rcp-name', async () => {
   // delay 2 seconds
   await new Promise(r => setTimeout(r, 2000))
@@ -49,8 +44,7 @@ rcp.preInit('rcp-name', async () => {
 
 ::: warning
 
-Do not pre-hook `rcp-fe-commom-libs`. It is used for the plugin loader, 
-so your callbacks sometimes will not triggered.
+Do not pre-hook `rcp-fe-commom-libs`. It is used for the plugin loader, so your callbacks sometimes will not triggered.
 
 :::
 
@@ -59,11 +53,9 @@ so your callbacks sometimes will not triggered.
 <Badge type="info" text="function" />
 <Badge type="tip" text="since v1.1.0" />
 
-Register a callback that will be triggered after the target plugin is loaded.
-Gives you an opportunity to access the plugin API.
+Register a callback that will be triggered after the target plugin is loaded. Gives you an opportunity to access the plugin API.
 
 ### Params
-
 - `name` - RCP name, should be prefixed with `rcp-`.
 - `callback` - A function will be triggered after the plugin is loaded.
 - `blocking` - A boolean value indicating whether this callback will be executed in blocking way. It's `false` by default.
@@ -79,8 +71,7 @@ rcp.postInit('rcp-name', (api) => {
 
 ::: tip
 
-`postInit` and `preInit` should be called before the target plugin loads, 
-preferably witin your plugin's `init` entry. So they will not work after the plugin is loaded.
+`postInit` and `preInit` should be called before the target plugin loads, preferably witin your plugin's `init` entry. So they will not work after the plugin is loaded.
 
 :::
 
@@ -89,52 +80,10 @@ preferably witin your plugin's `init` entry. So they will not work after the plu
 <Badge type="info" text="function" />
 <Badge type="tip" text="since v1.1.0" />
 
-This function works as same as `postInit` but allows you 
-to get the target plugin asynchronously and also works even after the plugin is loaded.
-
-Example with async context:
-
-```js
-const uikit = await rcp.whenReady('rcp-fe-lol-uikit')
-```
-
-Or with .then chain:
-
-```js
-rcp.whenReady('rcp-fe-lol-uikit')
-  .then(uikit => {
-    // do something
-  })
-```
-
-With multiple plugins:
-
-```js
-rcp.whenReady(['rcp-a', 'rcp-b', 'rcp-c'])
-  .then(([a, b, c]) => {
-    // do something
-  })
-```
-
-## rcp.get(name)
-
-<Badge type="info" text="function" />
-<Badge type="tip" text="since v1.1.0" />
-
-Get a RCP plugin synchronously after it's registered in the callbacks map.
+This function works as same as `postInit` but allows you to get the target plugin asynchronously and also works even after the plugin is loaded.
 
 Example:
 
 ```js
-// add to callbacks map
-rcp.whenReady('rcp-name')
-
-// call it somewhere after ready
-const api = rcp.get('rcp-name')
-```
-
-Common-libs always works:
-
-```js
-rcp.get('rcp-fe-common-libs')
+const uikit = await rcp.whenReady('rcp-fe-lol-uikit')
 ```

--- a/docs/runtime-api/socket.md
+++ b/docs/runtime-api/socket.md
@@ -1,4 +1,4 @@
-# LCU Socket observation
+# socket
 
 This namespace helps you to observe specific LCU APIs without creating a new WebSocket.
 You cannot get it directly from `window`, instead use the context of the [`init` entry point](../guide/javascript-plugin#plugin-entry-points).
@@ -8,32 +8,13 @@ You cannot get it directly from `window`, instead use the context of the [`init`
 <Badge type="info" text="function" />
 <Badge type="tip" text="since v1.1.0" />
 
-```ts
-function observe(
-  api: string,
-  listener: ApiListener
-): { disconnect: () => void }
-
-interface EventData {
-  data: any
-  uri: string
-  eventType: 'Create' | 'Update' | 'Delete'
-}
-
-interface ApiListener {
-  (message: EventData): void
-}
-```
-
 Subscribe a listener to listen when the given API endpoint get called.
 
 ### Params:
-
 - `api` a string that presents a LCU API endpoint.
 - `listener` a function that gets called with one data param.
 
 ### Return value:
-
 An object with a prop `disconnect` that could be called to disconnect the observer.
 
 Example:
@@ -48,9 +29,5 @@ socket.observe('/lol-matchmaking/v1/ready-check', (data) => {
 
 <Badge type="info" text="function" />
 <Badge type="tip" text="since v1.1.0" />
-
-```ts
-function disconnect(api: string, listener: ApiListener)
-```
 
 Disconnect a subscribed listener. The function parameters like the function above.

--- a/docs/runtime-api/toast.md
+++ b/docs/runtime-api/toast.md
@@ -7,14 +7,9 @@ This namespace is used to push your toast notifications onto the League Client s
 <Badge type="info" text="function" />
 <Badge type="tip" text="since v1.1.0" />
 
-```ts
-function success(message: string): void
-```
-
 Push a simple notification with a success checkmark.
 
 Params:
-
 - `message` a string to be shown on the notification.
 
 Example:
@@ -28,14 +23,9 @@ Toast.success('Welcome to my theme!')
 <Badge type="info" text="function" />
 <Badge type="tip" text="since v1.1.0" />
 
-```ts
-function error(message: string): void
-```
-
 Push a simple notification with a failure icon.
 
 Params:
-
 - `message` a string to be shown on the notification.
 
 Example:
@@ -49,19 +39,10 @@ Toast.error('Oops! Something went wrong.')
 <Badge type="info" text="function" />
 <Badge type="tip" text="since v1.1.0" />
 
-```ts
-function promise(promise: Promise<T>, msg: {
-  loading: string
-  success: string
-  error: string
-}): Promise<T>
-```
-
 Push a progress notification and wait for the given promise to complete.
 This function returns the given promise that is helpful for then/catch chain.
 
 Params:
-
 - `promise` a promise that the progress waits for.
 - `msg` an object with these properties:
   - `loading` a string message to be shown when the progress starts loading.

--- a/package.json
+++ b/package.json
@@ -5,12 +5,15 @@
   "license": "MIT",
   "type": "module",
   "scripts": {
+    "predev": "node scripts/generate-api.js",
+    "prebuild": "node scripts/generate-api.js",
     "dev": "vitepress dev",
     "build": "vitepress build",
     "preview": "vitepress preview"
   },
   "devDependencies": {
     "@types/node": "^18.14.6",
+    "ts-morph": "^27.0.2",
     "vitepress": "^1.0.0-rc.4",
     "vitepress-plugin-nprogress": "^0.0.4",
     "vitepress-plugin-tabs": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "license": "MIT",
   "type": "module",
   "scripts": {
-    "predev": "node scripts/generate-api.js",
-    "prebuild": "node scripts/generate-api.js",
+    "predev": "node scripts/generate-api.js && node scripts/generate-llms.js",
+    "prebuild": "node scripts/generate-api.js && node scripts/generate-llms.js",
     "dev": "vitepress dev",
     "build": "vitepress build",
     "preview": "vitepress preview"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,218 +1,140 @@
-lockfileVersion: '6.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-devDependencies:
-  '@types/node':
-    specifier: ^18.14.6
-    version: 18.14.6
-  vitepress:
-    specifier: ^1.0.0-rc.4
-    version: 1.0.0-rc.4(@types/node@18.14.6)
-  vitepress-plugin-nprogress:
-    specifier: ^0.0.4
-    version: 0.0.4
-  vitepress-plugin-tabs:
-    specifier: ^0.2.0
-    version: 0.2.0(vitepress@1.0.0-rc.4)(vue@3.3.4)
-  vue:
-    specifier: ^3.3.4
-    version: 3.3.4
+importers:
+
+  .:
+    devDependencies:
+      '@types/node':
+        specifier: ^18.14.6
+        version: 18.19.130
+      ts-morph:
+        specifier: ^27.0.2
+        version: 27.0.2
+      vitepress:
+        specifier: ^1.0.0-rc.4
+        version: 1.6.4(@algolia/client-search@5.49.0)(@types/node@18.19.130)(nprogress@0.2.0)(postcss@8.5.6)(search-insights@2.17.3)
+      vitepress-plugin-nprogress:
+        specifier: ^0.0.4
+        version: 0.0.4
+      vitepress-plugin-tabs:
+        specifier: ^0.2.0
+        version: 0.2.0(vitepress@1.6.4(@algolia/client-search@5.49.0)(@types/node@18.19.130)(nprogress@0.2.0)(postcss@8.5.6)(search-insights@2.17.3))(vue@3.5.28)
+      vue:
+        specifier: ^3.3.4
+        version: 3.5.28
 
 packages:
 
-  /@algolia/autocomplete-core@1.9.3(algoliasearch@4.17.0):
-    resolution: {integrity: sha512-009HdfugtGCdC4JdXUbVJClA0q0zh24yyePn+KUGk3rP7j8FEe/m5Yo/z65gn6nP/cM39PxpzqKrL7A6fP6PPw==}
-    dependencies:
-      '@algolia/autocomplete-plugin-algolia-insights': 1.9.3(algoliasearch@4.17.0)
-      '@algolia/autocomplete-shared': 1.9.3(algoliasearch@4.17.0)
-    transitivePeerDependencies:
-      - '@algolia/client-search'
-      - algoliasearch
-      - search-insights
-    dev: true
+  '@algolia/abtesting@1.15.0':
+    resolution: {integrity: sha512-D1QZ8dQx5zC9yrxNao9ER9bojmmzUdL1i2P9waIRiwnZ5fI26YswcCd6VHR/Q4W3PASfVf2My4YQ2FhGGDewTQ==}
+    engines: {node: '>= 14.0.0'}
 
-  /@algolia/autocomplete-plugin-algolia-insights@1.9.3(algoliasearch@4.17.0):
-    resolution: {integrity: sha512-a/yTUkcO/Vyy+JffmAnTWbr4/90cLzw+CC3bRbhnULr/EM0fGNvM13oQQ14f2moLMcVDyAx/leczLlAOovhSZg==}
+  '@algolia/autocomplete-core@1.17.7':
+    resolution: {integrity: sha512-BjiPOW6ks90UKl7TwMv7oNQMnzU+t/wk9mgIDi6b1tXpUek7MW0lbNOUHpvam9pe3lVCf4xPFT+lK7s+e+fs7Q==}
+
+  '@algolia/autocomplete-plugin-algolia-insights@1.17.7':
+    resolution: {integrity: sha512-Jca5Ude6yUOuyzjnz57og7Et3aXjbwCSDf/8onLHSQgw1qW3ALl9mrMWaXb5FmPVkV3EtkD2F/+NkT6VHyPu9A==}
     peerDependencies:
       search-insights: '>= 1 < 3'
-    peerDependenciesMeta:
-      search-insights:
-        optional: true
-    dependencies:
-      '@algolia/autocomplete-shared': 1.9.3(algoliasearch@4.17.0)
-    transitivePeerDependencies:
-      - '@algolia/client-search'
-      - algoliasearch
-    dev: true
 
-  /@algolia/autocomplete-preset-algolia@1.9.3(algoliasearch@4.17.0):
-    resolution: {integrity: sha512-d4qlt6YmrLMYy95n5TB52wtNDr6EgAIPH81dvvvW8UmuWRgxEtY0NJiPwl/h95JtG2vmRM804M0DSwMCNZlzRA==}
+  '@algolia/autocomplete-preset-algolia@1.17.7':
+    resolution: {integrity: sha512-ggOQ950+nwbWROq2MOCIL71RE0DdQZsceqrg32UqnhDz8FlO9rL8ONHNsI2R1MH0tkgVIDKI/D0sMiUchsFdWA==}
     peerDependencies:
       '@algolia/client-search': '>= 4.9.1 < 6'
       algoliasearch: '>= 4.9.1 < 6'
-    peerDependenciesMeta:
-      '@algolia/client-search':
-        optional: true
-    dependencies:
-      '@algolia/autocomplete-shared': 1.9.3(algoliasearch@4.17.0)
-      algoliasearch: 4.17.0
-    dev: true
 
-  /@algolia/autocomplete-shared@1.9.3(algoliasearch@4.17.0):
-    resolution: {integrity: sha512-Wnm9E4Ye6Rl6sTTqjoymD+l8DjSTHsHboVRYrKgEt8Q7UHm9nYbqhN/i0fhUYA3OAEH7WA8x3jfpnmJm3rKvaQ==}
+  '@algolia/autocomplete-shared@1.17.7':
+    resolution: {integrity: sha512-o/1Vurr42U/qskRSuhBH+VKxMvkkUVTLU6WZQr+L5lGZZLYWyhdzWjW0iGXY7EkwRTjBqvN2EsR81yCTGV/kmg==}
     peerDependencies:
       '@algolia/client-search': '>= 4.9.1 < 6'
       algoliasearch: '>= 4.9.1 < 6'
-    peerDependenciesMeta:
-      '@algolia/client-search':
-        optional: true
-    dependencies:
-      algoliasearch: 4.17.0
-    dev: true
 
-  /@algolia/cache-browser-local-storage@4.17.0:
-    resolution: {integrity: sha512-myRSRZDIMYB8uCkO+lb40YKiYHi0fjpWRtJpR/dgkaiBlSD0plRyB6lLOh1XIfmMcSeBOqDE7y9m8xZMrXYfyQ==}
-    dependencies:
-      '@algolia/cache-common': 4.17.0
-    dev: true
+  '@algolia/client-abtesting@5.49.0':
+    resolution: {integrity: sha512-Q1MSRhh4Du9WeLIl1S9O+BDUMaL01uuQtmzCyEzOBtu1xBDr3wvqrTJtfEceEkA5/Nw1BdGSHa6sDT3xTAF90A==}
+    engines: {node: '>= 14.0.0'}
 
-  /@algolia/cache-common@4.17.0:
-    resolution: {integrity: sha512-g8mXzkrcUBIPZaulAuqE7xyHhLAYAcF2xSch7d9dABheybaU3U91LjBX6eJTEB7XVhEsgK4Smi27vWtAJRhIKQ==}
-    dev: true
+  '@algolia/client-analytics@5.49.0':
+    resolution: {integrity: sha512-v50elhC80oyQw+8o8BwM+VvPuOo36+3W8VCfR4hsHoafQtGbMtP63U5eNcUydbVsM0py3JLoBaL1yKBK4L01sg==}
+    engines: {node: '>= 14.0.0'}
 
-  /@algolia/cache-in-memory@4.17.0:
-    resolution: {integrity: sha512-PT32ciC/xI8z919d0oknWVu3kMfTlhQn3MKxDln3pkn+yA7F7xrxSALysxquv+MhFfNAcrtQ/oVvQVBAQSHtdw==}
-    dependencies:
-      '@algolia/cache-common': 4.17.0
-    dev: true
+  '@algolia/client-common@5.49.0':
+    resolution: {integrity: sha512-BDmVDtpDvymfLE5YQ2cPnfWJUVTDJqwpJa03Fsb7yJFJmbeKsUOGsnRkYsTbdzf0FfcvyvBB5zdcbrAIL249bg==}
+    engines: {node: '>= 14.0.0'}
 
-  /@algolia/client-account@4.17.0:
-    resolution: {integrity: sha512-sSEHx9GA6m7wrlsSMNBGfyzlIfDT2fkz2u7jqfCCd6JEEwmxt8emGmxAU/0qBfbhRSuGvzojoLJlr83BSZAKjA==}
-    dependencies:
-      '@algolia/client-common': 4.17.0
-      '@algolia/client-search': 4.17.0
-      '@algolia/transporter': 4.17.0
-    dev: true
+  '@algolia/client-insights@5.49.0':
+    resolution: {integrity: sha512-lDCXsnZDx7zQ5GzSi1EL3l07EbksjrdpMgixFRCdi2QqeBe42HIQJfPPqdWtwrAXjORRopsPx2z+gGYJP/79Uw==}
+    engines: {node: '>= 14.0.0'}
 
-  /@algolia/client-analytics@4.17.0:
-    resolution: {integrity: sha512-84ooP8QA3mQ958hQ9wozk7hFUbAO+81CX1CjAuerxBqjKIInh1fOhXKTaku05O/GHBvcfExpPLIQuSuLYziBXQ==}
-    dependencies:
-      '@algolia/client-common': 4.17.0
-      '@algolia/client-search': 4.17.0
-      '@algolia/requester-common': 4.17.0
-      '@algolia/transporter': 4.17.0
-    dev: true
+  '@algolia/client-personalization@5.49.0':
+    resolution: {integrity: sha512-5k/KB+DsnesNKvMUEwTKSzExOf5zYbiPg7DVO7g1Y/+bhMb3wmxp9RFwfqwPfmoRTjptqvwhR6a0593tWVkmAw==}
+    engines: {node: '>= 14.0.0'}
 
-  /@algolia/client-common@4.17.0:
-    resolution: {integrity: sha512-jHMks0ZFicf8nRDn6ma8DNNsdwGgP/NKiAAL9z6rS7CymJ7L0+QqTJl3rYxRW7TmBhsUH40wqzmrG6aMIN/DrQ==}
-    dependencies:
-      '@algolia/requester-common': 4.17.0
-      '@algolia/transporter': 4.17.0
-    dev: true
+  '@algolia/client-query-suggestions@5.49.0':
+    resolution: {integrity: sha512-pjHNcrdjn7p3RQ5Ql1Baiwfdn9bkS+z4gqONJJP8kuZFqYP8Olthy4G7fl5bCB29UjdUj5EWlaElQKCtPluCtQ==}
+    engines: {node: '>= 14.0.0'}
 
-  /@algolia/client-personalization@4.17.0:
-    resolution: {integrity: sha512-RMzN4dZLIta1YuwT7QC9o+OeGz2cU6eTOlGNE/6RcUBLOU3l9tkCOdln5dPE2jp8GZXPl2yk54b2nSs1+pAjqw==}
-    dependencies:
-      '@algolia/client-common': 4.17.0
-      '@algolia/requester-common': 4.17.0
-      '@algolia/transporter': 4.17.0
-    dev: true
+  '@algolia/client-search@5.49.0':
+    resolution: {integrity: sha512-uGv2P3lcviuaZy8ZOAyN60cZdhOVyjXwaDC27a1qdp3Pb5Azn+lLSJwkHU4TNRpphHmIei9HZuUxwQroujdPjw==}
+    engines: {node: '>= 14.0.0'}
 
-  /@algolia/client-search@4.17.0:
-    resolution: {integrity: sha512-x4P2wKrrRIXszT8gb7eWsMHNNHAJs0wE7/uqbufm4tZenAp+hwU/hq5KVsY50v+PfwM0LcDwwn/1DroujsTFoA==}
-    dependencies:
-      '@algolia/client-common': 4.17.0
-      '@algolia/requester-common': 4.17.0
-      '@algolia/transporter': 4.17.0
-    dev: true
+  '@algolia/ingestion@1.49.0':
+    resolution: {integrity: sha512-sH10mftYlmvfGbvAgTtHYbCIstmNUdiAkX//0NAyBcJRB6NnZmNsdLxdFGbE8ZqlGXzoe0zcUIau+DxKpXtqCw==}
+    engines: {node: '>= 14.0.0'}
 
-  /@algolia/logger-common@4.17.0:
-    resolution: {integrity: sha512-DGuoZqpTmIKJFDeyAJ7M8E/LOenIjWiOsg1XJ1OqAU/eofp49JfqXxbfgctlVZVmDABIyOz8LqEoJ6ZP4DTyvw==}
-    dev: true
+  '@algolia/monitoring@1.49.0':
+    resolution: {integrity: sha512-RqhGcVVxLpK+lA0GZKywlQIXsI704flc12nv/hOdrwiuk/Uyhxs46KLM4ngip7wutU+7t0PYZWiVayrqBPN/ZQ==}
+    engines: {node: '>= 14.0.0'}
 
-  /@algolia/logger-console@4.17.0:
-    resolution: {integrity: sha512-zMPvugQV/gbXUvWBCzihw6m7oxIKp48w37QBIUu/XqQQfxhjoOE9xyfJr1KldUt5FrYOKZJVsJaEjTsu+bIgQg==}
-    dependencies:
-      '@algolia/logger-common': 4.17.0
-    dev: true
+  '@algolia/recommend@5.49.0':
+    resolution: {integrity: sha512-kg8omGRvmIPhhqtUqSIpS3regFKWuoWh3WqyUhGk27N4T7q8I++8TsDYsV8vK7oBEzw706m2vUBtN5fw2fDjmw==}
+    engines: {node: '>= 14.0.0'}
 
-  /@algolia/requester-browser-xhr@4.17.0:
-    resolution: {integrity: sha512-aSOX/smauyTkP21Pf52pJ1O2LmNFJ5iHRIzEeTh0mwBeADO4GdG94cAWDILFA9rNblq/nK3EDh3+UyHHjplZ1A==}
-    dependencies:
-      '@algolia/requester-common': 4.17.0
-    dev: true
+  '@algolia/requester-browser-xhr@5.49.0':
+    resolution: {integrity: sha512-BaZ6NTI9VdSbDcsMucdKhTuFFxv6B+3dAZZBozX12fKopYsELh7dBLfZwm8evDCIicmNjIjobi4VNnNshrCSuw==}
+    engines: {node: '>= 14.0.0'}
 
-  /@algolia/requester-common@4.17.0:
-    resolution: {integrity: sha512-XJjmWFEUlHu0ijvcHBoixuXfEoiRUdyzQM6YwTuB8usJNIgShua8ouFlRWF8iCeag0vZZiUm4S2WCVBPkdxFgg==}
-    dev: true
+  '@algolia/requester-fetch@5.49.0':
+    resolution: {integrity: sha512-2nxISxS5xO5DLAj6QzMImgJv6CqpZhJVkhcTFULESR/k4IpbkJTEHmViVTxw9MlrU8B5GfwHevFd7vKL3a7MXQ==}
+    engines: {node: '>= 14.0.0'}
 
-  /@algolia/requester-node-http@4.17.0:
-    resolution: {integrity: sha512-bpb/wDA1aC6WxxM8v7TsFspB7yBN3nqCGs2H1OADolQR/hiAIjAxusbuMxVbRFOdaUvAIqioIIkWvZdpYNIn8w==}
-    dependencies:
-      '@algolia/requester-common': 4.17.0
-    dev: true
+  '@algolia/requester-node-http@5.49.0':
+    resolution: {integrity: sha512-S/B94C6piEUXGpN3y5ysmNKMEqdfNVAXYY+FxivEAV5IGJjbEuLZfT8zPPZUWGw9vh6lgP80Hye2G5aVBNIa8Q==}
+    engines: {node: '>= 14.0.0'}
 
-  /@algolia/transporter@4.17.0:
-    resolution: {integrity: sha512-6xL6H6fe+Fi0AEP3ziSgC+G04RK37iRb4uUUqVAH9WPYFI8g+LYFq6iv5HS8Cbuc5TTut+Bwj6G+dh/asdb9uA==}
-    dependencies:
-      '@algolia/cache-common': 4.17.0
-      '@algolia/logger-common': 4.17.0
-      '@algolia/requester-common': 4.17.0
-    dev: true
-
-  /@babel/helper-string-parser@7.19.4:
-    resolution: {integrity: sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==}
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
-    dev: true
 
-  /@babel/helper-validator-identifier@7.19.1:
-    resolution: {integrity: sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==}
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
-    dev: true
 
-  /@babel/parser@7.21.4:
-    resolution: {integrity: sha512-alVJj7k7zIxqBZ7BTRhz0IqJFxW1VJbm6N8JbcYhQ186df9ZBPbZBmWSqAMXwHGsCJdYks7z/voa3ibiS5bCIw==}
+  '@babel/parser@7.29.0':
+    resolution: {integrity: sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==}
     engines: {node: '>=6.0.0'}
     hasBin: true
-    dependencies:
-      '@babel/types': 7.21.4
-    dev: true
 
-  /@babel/types@7.21.4:
-    resolution: {integrity: sha512-rU2oY501qDxE8Pyo7i/Orqma4ziCOrby0/9mvbDUGEfvZjb279Nk9k19e2fiCxHbRRpY2ZyrgW1eq22mvmOIzA==}
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/helper-string-parser': 7.19.4
-      '@babel/helper-validator-identifier': 7.19.1
-      to-fast-properties: 2.0.0
-    dev: true
 
-  /@docsearch/css@3.5.1:
-    resolution: {integrity: sha512-2Pu9HDg/uP/IT10rbQ+4OrTQuxIWdKVUEdcw9/w7kZJv9NeHS6skJx1xuRiFyoGKwAzcHXnLp7csE99sj+O1YA==}
-    dev: true
+  '@docsearch/css@3.8.2':
+    resolution: {integrity: sha512-y05ayQFyUmCXze79+56v/4HpycYF3uFqB78pLPrSV5ZKAlDuIAAJNhaRi8tTdRNXh05yxX/TyNnzD6LwSM89vQ==}
 
-  /@docsearch/js@3.5.1:
-    resolution: {integrity: sha512-EXi8de5njxgP6TV3N9ytnGRLG9zmBNTEZjR4VzwPcpPLbZxxTLG2gaFyJyKiFVQxHW/DPlMrDJA3qoRRGEkgZw==}
-    dependencies:
-      '@docsearch/react': 3.5.1
-      preact: 10.13.2
-    transitivePeerDependencies:
-      - '@algolia/client-search'
-      - '@types/react'
-      - react
-      - react-dom
-      - search-insights
-    dev: true
+  '@docsearch/js@3.8.2':
+    resolution: {integrity: sha512-Q5wY66qHn0SwA7Taa0aDbHiJvaFJLOJyHmooQ7y8hlwwQLQ/5WwCcoX0g7ii04Qi2DJlHsd0XXzJ8Ypw9+9YmQ==}
 
-  /@docsearch/react@3.5.1:
-    resolution: {integrity: sha512-t5mEODdLzZq4PTFAm/dvqcvZFdPDMdfPE5rJS5SC8OUq9mPzxEy6b+9THIqNM9P0ocCb4UC5jqBrxKclnuIbzQ==}
+  '@docsearch/react@3.8.2':
+    resolution: {integrity: sha512-xCRrJQlTt8N9GU0DG4ptwHRkfnSnD/YpdeaXe02iKfqs97TkZJv60yE+1eq/tjPcVnTW8dP5qLP7itifFVV5eg==}
     peerDependencies:
       '@types/react': '>= 16.8.0 < 19.0.0'
       react: '>= 16.8.0 < 19.0.0'
       react-dom: '>= 16.8.0 < 19.0.0'
+      search-insights: '>= 1 < 3'
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -220,351 +142,414 @@ packages:
         optional: true
       react-dom:
         optional: true
-    dependencies:
-      '@algolia/autocomplete-core': 1.9.3(algoliasearch@4.17.0)
-      '@algolia/autocomplete-preset-algolia': 1.9.3(algoliasearch@4.17.0)
-      '@docsearch/css': 3.5.1
-      algoliasearch: 4.17.0
-    transitivePeerDependencies:
-      - '@algolia/client-search'
-      - search-insights
-    dev: true
+      search-insights:
+        optional: true
 
-  /@esbuild/android-arm64@0.18.16:
-    resolution: {integrity: sha512-wsCqSPqLz+6Ov+OM4EthU43DyYVVyfn15S4j1bJzylDpc1r1jZFFfJQNfDuT8SlgwuqpmpJXK4uPlHGw6ve7eA==}
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/android-arm@0.18.16:
-    resolution: {integrity: sha512-gCHjjQmA8L0soklKbLKA6pgsLk1byULuHe94lkZDzcO3/Ta+bbeewJioEn1Fr7kgy9NWNFy/C+MrBwC6I/WCug==}
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/android-x64@0.18.16:
-    resolution: {integrity: sha512-ldsTXolyA3eTQ1//4DS+E15xl0H/3DTRJaRL0/0PgkqDsI0fV/FlOtD+h0u/AUJr+eOTlZv4aC9gvfppo3C4sw==}
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/darwin-arm64@0.18.16:
-    resolution: {integrity: sha512-aBxruWCII+OtluORR/KvisEw0ALuw/qDQWvkoosA+c/ngC/Kwk0lLaZ+B++LLS481/VdydB2u6tYpWxUfnLAIw==}
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/darwin-x64@0.18.16:
-    resolution: {integrity: sha512-6w4Dbue280+rp3LnkgmriS1icOUZDyPuZo/9VsuMUTns7SYEiOaJ7Ca1cbhu9KVObAWfmdjUl4gwy9TIgiO5eA==}
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/freebsd-arm64@0.18.16:
-    resolution: {integrity: sha512-x35fCebhe9s979DGKbVAwXUOcTmCIE32AIqB9CB1GralMIvxdnMLAw5CnID17ipEw9/3MvDsusj/cspYt2ZLNQ==}
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [freebsd]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/freebsd-x64@0.18.16:
-    resolution: {integrity: sha512-YM98f+PeNXF3GbxIJlUsj+McUWG1irguBHkszCIwfr3BXtXZsXo0vqybjUDFfu9a8Wr7uUD/YSmHib+EeGAFlg==}
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [freebsd]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/linux-arm64@0.18.16:
-    resolution: {integrity: sha512-XIqhNUxJiuy+zsR77+H5Z2f7s4YRlriSJKtvx99nJuG5ATuJPjmZ9n0ANgnGlPCpXGSReFpgcJ7O3SMtzIFeiQ==}
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/linux-arm@0.18.16:
-    resolution: {integrity: sha512-b5ABb+5Ha2C9JkeZXV+b+OruR1tJ33ePmv9ZwMeETSEKlmu/WJ45XTTG+l6a2KDsQtJJ66qo/hbSGBtk0XVLHw==}
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/linux-ia32@0.18.16:
-    resolution: {integrity: sha512-no+pfEpwnRvIyH+txbBAWtjxPU9grslmTBfsmDndj7bnBmr55rOo/PfQmRfz7Qg9isswt1FP5hBbWb23fRWnow==}
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/linux-loong64@0.18.16:
-    resolution: {integrity: sha512-Zbnczs9ZXjmo0oZSS0zbNlJbcwKXa/fcNhYQjahDs4Xg18UumpXG/lwM2lcSvHS3mTrRyCYZvJbmzYc4laRI1g==}
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
     engines: {node: '>=12'}
     cpu: [loong64]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/linux-mips64el@0.18.16:
-    resolution: {integrity: sha512-YMF7hih1HVR/hQVa/ot4UVffc5ZlrzEb3k2ip0nZr1w6fnYypll9td2qcoMLvd3o8j3y6EbJM3MyIcXIVzXvQQ==}
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
     engines: {node: '>=12'}
     cpu: [mips64el]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/linux-ppc64@0.18.16:
-    resolution: {integrity: sha512-Wkz++LZ29lDwUyTSEnzDaaP5OveOgTU69q9IyIw9WqLRxM4BjTBjz9un4G6TOvehWpf/J3gYVFN96TjGHrbcNQ==}
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/linux-riscv64@0.18.16:
-    resolution: {integrity: sha512-LFMKZ30tk78/mUv1ygvIP+568bwf4oN6reG/uczXnz6SvFn4e2QUFpUpZY9iSJT6Qpgstrhef/nMykIXZtZWGQ==}
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
     engines: {node: '>=12'}
     cpu: [riscv64]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/linux-s390x@0.18.16:
-    resolution: {integrity: sha512-3ZC0BgyYHYKfZo3AV2/66TD/I9tlSBaW7eWTEIkrQQKfJIifKMMttXl9FrAg+UT0SGYsCRLI35Gwdmm96vlOjg==}
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
     engines: {node: '>=12'}
     cpu: [s390x]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/linux-x64@0.18.16:
-    resolution: {integrity: sha512-xu86B3647DihHJHv/wx3NCz2Dg1gjQ8bbf9cVYZzWKY+gsvxYmn/lnVlqDRazObc3UMwoHpUhNYaZset4X8IPA==}
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/netbsd-x64@0.18.16:
-    resolution: {integrity: sha512-uVAgpimx9Ffw3xowtg/7qQPwHFx94yCje+DoBx+LNm2ePDpQXHrzE+Sb0Si2VBObYz+LcRps15cq+95YM7gkUw==}
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/openbsd-x64@0.18.16:
-    resolution: {integrity: sha512-6OjCQM9wf7z8/MBi6BOWaTL2AS/SZudsZtBziXMtNI8r/U41AxS9x7jn0ATOwVy08OotwkPqGRMkpPR2wcTJXA==}
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [openbsd]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/sunos-x64@0.18.16:
-    resolution: {integrity: sha512-ZoNkruFYJp9d1LbUYCh8awgQDvB9uOMZqlQ+gGEZR7v6C+N6u7vPr86c+Chih8niBR81Q/bHOSKGBK3brJyvkQ==}
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [sunos]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/win32-arm64@0.18.16:
-    resolution: {integrity: sha512-+j4anzQ9hrs+iqO+/wa8UE6TVkKua1pXUb0XWFOx0FiAj6R9INJ+WE//1/Xo6FG1vB5EpH3ko+XcgwiDXTxcdw==}
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/win32-ia32@0.18.16:
-    resolution: {integrity: sha512-5PFPmq3sSKTp9cT9dzvI67WNfRZGvEVctcZa1KGjDDu4n3H8k59Inbk0du1fz0KrAbKKNpJbdFXQMDUz7BG4rQ==}
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/win32-x64@0.18.16:
-    resolution: {integrity: sha512-sCIVrrtcWN5Ua7jYXNG1xD199IalrbfV2+0k/2Zf2OyV2FtnQnMgdzgpRAbi4AWlKJj1jkX+M+fEGPQj6BQB4w==}
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@jridgewell/sourcemap-codec@1.4.15:
-    resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
-    dev: true
+  '@iconify-json/simple-icons@1.2.71':
+    resolution: {integrity: sha512-rNoDFbq1fAYiEexBvrw613/xiUOPEu5MKVV/X8lI64AgdTzLQUUemr9f9fplxUMPoxCBP2rWzlhOEeTHk/Sf0Q==}
 
-  /@types/node@18.14.6:
-    resolution: {integrity: sha512-93+VvleD3mXwlLI/xASjw0FzKcwzl3OdTCzm1LaRfqgS21gfFtK3zDXM5Op9TeeMsJVOaJ2VRDpT9q4Y3d0AvA==}
-    dev: true
+  '@iconify/types@2.0.0':
+    resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
 
-  /@types/web-bluetooth@0.0.17:
-    resolution: {integrity: sha512-4p9vcSmxAayx72yn70joFoL44c9MO/0+iVEBIQXe3v2h2SiAsEIo/G5v6ObFWvNKRFjbrVadNf9LqEEZeQPzdA==}
-    dev: true
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
-  /@vitejs/plugin-vue@4.2.3(vite@4.4.9)(vue@3.3.4):
-    resolution: {integrity: sha512-R6JDUfiZbJA9cMiguQ7jxALsgiprjBeHL5ikpXfJCH62pPHtI+JdJ5xWj6Ev73yXSlYl86+blXn1kZHQ7uElxw==}
-    engines: {node: ^14.18.0 || >=16.0.0}
+  '@rollup/rollup-android-arm-eabi@4.58.0':
+    resolution: {integrity: sha512-mr0tmS/4FoVk1cnaeN244A/wjvGDNItZKR8hRhnmCzygyRXYtKF5jVDSIILR1U97CTzAYmbgIj/Dukg62ggG5w==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.58.0':
+    resolution: {integrity: sha512-+s++dbp+/RTte62mQD9wLSbiMTV+xr/PeRJEc/sFZFSBRlHPNPVaf5FXlzAL77Mr8FtSfQqCN+I598M8U41ccQ==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.58.0':
+    resolution: {integrity: sha512-MFWBwTcYs0jZbINQBXHfSrpSQJq3IUOakcKPzfeSznONop14Pxuqa0Kg19GD0rNBMPQI2tFtu3UzapZpH0Uc1Q==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.58.0':
+    resolution: {integrity: sha512-yiKJY7pj9c9JwzuKYLFaDZw5gma3fI9bkPEIyofvVfsPqjCWPglSHdpdwXpKGvDeYDms3Qal8qGMEHZ1M/4Udg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.58.0':
+    resolution: {integrity: sha512-x97kCoBh5MOevpn/CNK9W1x8BEzO238541BGWBc315uOlN0AD/ifZ1msg+ZQB05Ux+VF6EcYqpiagfLJ8U3LvQ==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.58.0':
+    resolution: {integrity: sha512-Aa8jPoZ6IQAG2eIrcXPpjRcMjROMFxCt1UYPZZtCxRV68WkuSigYtQ/7Zwrcr2IvtNJo7T2JfDXyMLxq5L4Jlg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.58.0':
+    resolution: {integrity: sha512-Ob8YgT5kD/lSIYW2Rcngs5kNB/44Q2RzBSPz9brf2WEtcGR7/f/E9HeHn1wYaAwKBni+bdXEwgHvUd0x12lQSA==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.58.0':
+    resolution: {integrity: sha512-K+RI5oP1ceqoadvNt1FecL17Qtw/n9BgRSzxif3rTL2QlIu88ccvY+Y9nnHe/cmT5zbH9+bpiJuG1mGHRVwF4Q==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.58.0':
+    resolution: {integrity: sha512-T+17JAsCKUjmbopcKepJjHWHXSjeW7O5PL7lEFaeQmiVyw4kkc5/lyYKzrv6ElWRX/MrEWfPiJWqbTvfIvjM1Q==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.58.0':
+    resolution: {integrity: sha512-cCePktb9+6R9itIJdeCFF9txPU7pQeEHB5AbHu/MKsfH/k70ZtOeq1k4YAtBv9Z7mmKI5/wOLYjQ+B9QdxR6LA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.58.0':
+    resolution: {integrity: sha512-iekUaLkfliAsDl4/xSdoCJ1gnnIXvoNz85C8U8+ZxknM5pBStfZjeXgB8lXobDQvvPRCN8FPmmuTtH+z95HTmg==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.58.0':
+    resolution: {integrity: sha512-68ofRgJNl/jYJbxFjCKE7IwhbfxOl1muPN4KbIqAIe32lm22KmU7E8OPvyy68HTNkI2iV/c8y2kSPSm2mW/Q9Q==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.58.0':
+    resolution: {integrity: sha512-dpz8vT0i+JqUKuSNPCP5SYyIV2Lh0sNL1+FhM7eLC457d5B9/BC3kDPp5BBftMmTNsBarcPcoz5UGSsnCiw4XQ==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.58.0':
+    resolution: {integrity: sha512-4gdkkf9UJ7tafnweBCR/mk4jf3Jfl0cKX9Np80t5i78kjIH0ZdezUv/JDI2VtruE5lunfACqftJ8dIMGN4oHew==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.58.0':
+    resolution: {integrity: sha512-YFS4vPnOkDTD/JriUeeZurFYoJhPf9GQQEF/v4lltp3mVcBmnsAdjEWhr2cjUCZzZNzxCG0HZOvJU44UGHSdzw==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.58.0':
+    resolution: {integrity: sha512-x2xgZlFne+QVNKV8b4wwaCS8pwq3y14zedZ5DqLzjdRITvreBk//4Knbcvm7+lWmms9V9qFp60MtUd0/t/PXPw==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.58.0':
+    resolution: {integrity: sha512-jIhrujyn4UnWF8S+DHSkAkDEO3hLX0cjzxJZPLF80xFyzyUIYgSMRcYQ3+uqEoyDD2beGq7Dj7edi8OnJcS/hg==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.58.0':
+    resolution: {integrity: sha512-+410Srdoh78MKSJxTQ+hZ/Mx+ajd6RjjPwBPNd0R3J9FtL6ZA0GqiiyNjCO9In0IzZkCNrpGymSfn+kgyPQocg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.58.0':
+    resolution: {integrity: sha512-ZjMyby5SICi227y1MTR3VYBpFTdZs823Rs/hpakufleBoufoOIB6jtm9FEoxn/cgO7l6PM2rCEl5Kre5vX0QrQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.58.0':
+    resolution: {integrity: sha512-ds4iwfYkSQ0k1nb8LTcyXw//ToHOnNTJtceySpL3fa7tc/AsE+UpUFphW126A6fKBGJD5dhRvg8zw1rvoGFxmw==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.58.0':
+    resolution: {integrity: sha512-fd/zpJniln4ICdPkjWFhZYeY/bpnaN9pGa6ko+5WD38I0tTqk9lXMgXZg09MNdhpARngmxiCg0B0XUamNw/5BQ==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.58.0':
+    resolution: {integrity: sha512-YpG8dUOip7DCz3nr/JUfPbIUo+2d/dy++5bFzgi4ugOGBIox+qMbbqt/JoORwvI/C9Kn2tz6+Bieoqd5+B1CjA==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.58.0':
+    resolution: {integrity: sha512-b9DI8jpFQVh4hIXFr0/+N/TzLdpBIoPzjt0Rt4xJbW3mzguV3mduR9cNgiuFcuL/TeORejJhCWiAXe3E/6PxWA==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.58.0':
+    resolution: {integrity: sha512-CSrVpmoRJFN06LL9xhkitkwUcTZtIotYAF5p6XOR2zW0Zz5mzb3IPpcoPhB02frzMHFNo1reQ9xSF5fFm3hUsQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.58.0':
+    resolution: {integrity: sha512-QFsBgQNTnh5K0t/sBsjJLq24YVqEIVkGpfN2VHsnN90soZyhaiA9UUHufcctVNL4ypJY0wrwad0wslx2KJQ1/w==}
+    cpu: [x64]
+    os: [win32]
+
+  '@shikijs/core@2.5.0':
+    resolution: {integrity: sha512-uu/8RExTKtavlpH7XqnVYBrfBkUc20ngXiX9NSrBhOVZYv/7XQRKUyhtkeflY5QsxC0GbJThCerruZfsUaSldg==}
+
+  '@shikijs/engine-javascript@2.5.0':
+    resolution: {integrity: sha512-VjnOpnQf8WuCEZtNUdjjwGUbtAVKuZkVQ/5cHy/tojVVRIRtlWMYVjyWhxOmIq05AlSOv72z7hRNRGVBgQOl0w==}
+
+  '@shikijs/engine-oniguruma@2.5.0':
+    resolution: {integrity: sha512-pGd1wRATzbo/uatrCIILlAdFVKdxImWJGQ5rFiB5VZi2ve5xj3Ax9jny8QvkaV93btQEwR/rSz5ERFpC5mKNIw==}
+
+  '@shikijs/langs@2.5.0':
+    resolution: {integrity: sha512-Qfrrt5OsNH5R+5tJ/3uYBBZv3SuGmnRPejV9IlIbFH3HTGLDlkqgHymAlzklVmKBjAaVmkPkyikAV/sQ1wSL+w==}
+
+  '@shikijs/themes@2.5.0':
+    resolution: {integrity: sha512-wGrk+R8tJnO0VMzmUExHR+QdSaPUl/NKs+a4cQQRWyoc3YFbUzuLEi/KWK1hj+8BfHRKm2jNhhJck1dfstJpiw==}
+
+  '@shikijs/transformers@2.5.0':
+    resolution: {integrity: sha512-SI494W5X60CaUwgi8u4q4m4s3YAFSxln3tzNjOSYqq54wlVgz0/NbbXEb3mdLbqMBztcmS7bVTaEd2w0qMmfeg==}
+
+  '@shikijs/types@2.5.0':
+    resolution: {integrity: sha512-ygl5yhxki9ZLNuNpPitBWvcy9fsSKKaRuO4BAlMyagszQidxcpLAr0qiW/q43DtSIDxO6hEbtYLiFZNXO/hdGw==}
+
+  '@shikijs/vscode-textmate@10.0.2':
+    resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
+
+  '@ts-morph/common@0.28.1':
+    resolution: {integrity: sha512-W74iWf7ILp1ZKNYXY5qbddNaml7e9Sedv5lvU1V8lftlitkc9Pq1A+jlH23ltDgWYeZFFEqGCD1Ies9hqu3O+g==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/hast@3.0.4':
+    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
+  '@types/linkify-it@5.0.0':
+    resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
+
+  '@types/markdown-it@14.1.2':
+    resolution: {integrity: sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==}
+
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/mdurl@2.0.0':
+    resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
+
+  '@types/node@18.19.130':
+    resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@types/web-bluetooth@0.0.21':
+    resolution: {integrity: sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==}
+
+  '@ungap/structured-clone@1.3.0':
+    resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+
+  '@vitejs/plugin-vue@5.2.4':
+    resolution: {integrity: sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
     peerDependencies:
-      vite: ^4.0.0
+      vite: ^5.0.0 || ^6.0.0
       vue: ^3.2.25
-    dependencies:
-      vite: 4.4.9(@types/node@18.14.6)
-      vue: 3.3.4
-    dev: true
 
-  /@vue/compiler-core@3.3.4:
-    resolution: {integrity: sha512-cquyDNvZ6jTbf/+x+AgM2Arrp6G4Dzbb0R64jiG804HRMfRiFXWI6kqUVqZ6ZR0bQhIoQjB4+2bhNtVwndW15g==}
-    dependencies:
-      '@babel/parser': 7.21.4
-      '@vue/shared': 3.3.4
-      estree-walker: 2.0.2
-      source-map-js: 1.0.2
-    dev: true
+  '@vue/compiler-core@3.5.28':
+    resolution: {integrity: sha512-kviccYxTgoE8n6OCw96BNdYlBg2GOWfBuOW4Vqwrt7mSKWKwFVvI8egdTltqRgITGPsTFYtKYfxIG8ptX2PJHQ==}
 
-  /@vue/compiler-dom@3.3.4:
-    resolution: {integrity: sha512-wyM+OjOVpuUukIq6p5+nwHYtj9cFroz9cwkfmP9O1nzH68BenTTv0u7/ndggT8cIQlnBeOo6sUT/gvHcIkLA5w==}
-    dependencies:
-      '@vue/compiler-core': 3.3.4
-      '@vue/shared': 3.3.4
-    dev: true
+  '@vue/compiler-dom@3.5.28':
+    resolution: {integrity: sha512-/1ZepxAb159jKR1btkefDP+J2xuWL5V3WtleRmxaT+K2Aqiek/Ab/+Ebrw2pPj0sdHO8ViAyyJWfhXXOP/+LQA==}
 
-  /@vue/compiler-sfc@3.3.4:
-    resolution: {integrity: sha512-6y/d8uw+5TkCuzBkgLS0v3lSM3hJDntFEiUORM11pQ/hKvkhSKZrXW6i69UyXlJQisJxuUEJKAWEqWbWsLeNKQ==}
-    dependencies:
-      '@babel/parser': 7.21.4
-      '@vue/compiler-core': 3.3.4
-      '@vue/compiler-dom': 3.3.4
-      '@vue/compiler-ssr': 3.3.4
-      '@vue/reactivity-transform': 3.3.4
-      '@vue/shared': 3.3.4
-      estree-walker: 2.0.2
-      magic-string: 0.30.1
-      postcss: 8.4.27
-      source-map-js: 1.0.2
-    dev: true
+  '@vue/compiler-sfc@3.5.28':
+    resolution: {integrity: sha512-6TnKMiNkd6u6VeVDhZn/07KhEZuBSn43Wd2No5zaP5s3xm8IqFTHBj84HJah4UepSUJTro5SoqqlOY22FKY96g==}
 
-  /@vue/compiler-ssr@3.3.4:
-    resolution: {integrity: sha512-m0v6oKpup2nMSehwA6Uuu+j+wEwcy7QmwMkVNVfrV9P2qE5KshC6RwOCq8fjGS/Eak/uNb8AaWekfiXxbBB6gQ==}
-    dependencies:
-      '@vue/compiler-dom': 3.3.4
-      '@vue/shared': 3.3.4
-    dev: true
+  '@vue/compiler-ssr@3.5.28':
+    resolution: {integrity: sha512-JCq//9w1qmC6UGLWJX7RXzrGpKkroubey/ZFqTpvEIDJEKGgntuDMqkuWiZvzTzTA5h2qZvFBFHY7fAAa9475g==}
 
-  /@vue/devtools-api@6.5.0:
-    resolution: {integrity: sha512-o9KfBeaBmCKl10usN4crU53fYtC1r7jJwdGKjPT24t348rHxgfpZ0xL3Xm/gLUYnc0oTp8LAmrxOeLyu6tbk2Q==}
-    dev: true
+  '@vue/devtools-api@7.7.9':
+    resolution: {integrity: sha512-kIE8wvwlcZ6TJTbNeU2HQNtaxLx3a84aotTITUuL/4bzfPxzajGBOoqjMhwZJ8L9qFYDU/lAYMEEm11dnZOD6g==}
 
-  /@vue/reactivity-transform@3.3.4:
-    resolution: {integrity: sha512-MXgwjako4nu5WFLAjpBnCj/ieqcjE2aJBINUNQzkZQfzIZA4xn+0fV1tIYBJvvva3N3OvKGofRLvQIwEQPpaXw==}
-    dependencies:
-      '@babel/parser': 7.21.4
-      '@vue/compiler-core': 3.3.4
-      '@vue/shared': 3.3.4
-      estree-walker: 2.0.2
-      magic-string: 0.30.1
-    dev: true
+  '@vue/devtools-kit@7.7.9':
+    resolution: {integrity: sha512-PyQ6odHSgiDVd4hnTP+aDk2X4gl2HmLDfiyEnn3/oV+ckFDuswRs4IbBT7vacMuGdwY/XemxBoh302ctbsptuA==}
 
-  /@vue/reactivity@3.3.4:
-    resolution: {integrity: sha512-kLTDLwd0B1jG08NBF3R5rqULtv/f8x3rOFByTDz4J53ttIQEDmALqKqXY0J+XQeN0aV2FBxY8nJDf88yvOPAqQ==}
-    dependencies:
-      '@vue/shared': 3.3.4
-    dev: true
+  '@vue/devtools-shared@7.7.9':
+    resolution: {integrity: sha512-iWAb0v2WYf0QWmxCGy0seZNDPdO3Sp5+u78ORnyeonS6MT4PC7VPrryX2BpMJrwlDeaZ6BD4vP4XKjK0SZqaeA==}
 
-  /@vue/runtime-core@3.3.4:
-    resolution: {integrity: sha512-R+bqxMN6pWO7zGI4OMlmvePOdP2c93GsHFM/siJI7O2nxFRzj55pLwkpCedEY+bTMgp5miZ8CxfIZo3S+gFqvA==}
-    dependencies:
-      '@vue/reactivity': 3.3.4
-      '@vue/shared': 3.3.4
-    dev: true
+  '@vue/reactivity@3.5.28':
+    resolution: {integrity: sha512-gr5hEsxvn+RNyu9/9o1WtdYdwDjg5FgjUSBEkZWqgTKlo/fvwZ2+8W6AfKsc9YN2k/+iHYdS9vZYAhpi10kNaw==}
 
-  /@vue/runtime-dom@3.3.4:
-    resolution: {integrity: sha512-Aj5bTJ3u5sFsUckRghsNjVTtxZQ1OyMWCr5dZRAPijF/0Vy4xEoRCwLyHXcj4D0UFbJ4lbx3gPTgg06K/GnPnQ==}
-    dependencies:
-      '@vue/runtime-core': 3.3.4
-      '@vue/shared': 3.3.4
-      csstype: 3.1.2
-    dev: true
+  '@vue/runtime-core@3.5.28':
+    resolution: {integrity: sha512-POVHTdbgnrBBIpnbYU4y7pOMNlPn2QVxVzkvEA2pEgvzbelQq4ZOUxbp2oiyo+BOtiYlm8Q44wShHJoBvDPAjQ==}
 
-  /@vue/server-renderer@3.3.4(vue@3.3.4):
-    resolution: {integrity: sha512-Q6jDDzR23ViIb67v+vM1Dqntu+HUexQcsWKhhQa4ARVzxOY2HbC7QRW/ggkDBd5BU+uM1sV6XOAP0b216o34JQ==}
+  '@vue/runtime-dom@3.5.28':
+    resolution: {integrity: sha512-4SXxSF8SXYMuhAIkT+eBRqOkWEfPu6nhccrzrkioA6l0boiq7sp18HCOov9qWJA5HML61kW8p/cB4MmBiG9dSA==}
+
+  '@vue/server-renderer@3.5.28':
+    resolution: {integrity: sha512-pf+5ECKGj8fX95bNincbzJ6yp6nyzuLDhYZCeFxUNp8EBrQpPpQaLX3nNCp49+UbgbPun3CeVE+5CXVV1Xydfg==}
     peerDependencies:
-      vue: 3.3.4
-    dependencies:
-      '@vue/compiler-ssr': 3.3.4
-      '@vue/shared': 3.3.4
-      vue: 3.3.4
-    dev: true
+      vue: 3.5.28
 
-  /@vue/shared@3.3.4:
-    resolution: {integrity: sha512-7OjdcV8vQ74eiz1TZLzZP4JwqM5fA94K6yntPS5Z25r9HDuGNzaGdgvwKYq6S+MxwF0TFRwe50fIR/MYnakdkQ==}
-    dev: true
+  '@vue/shared@3.5.28':
+    resolution: {integrity: sha512-cfWa1fCGBxrvaHRhvV3Is0MgmrbSCxYTXCSCau2I0a1Xw1N1pHAvkWCiXPRAqjvToILvguNyEwjevUqAuBQWvQ==}
 
-  /@vueuse/core@10.3.0(vue@3.3.4):
-    resolution: {integrity: sha512-BEM5yxcFKb5btFjTSAFjTu5jmwoW66fyV9uJIP4wUXXU8aR5Hl44gndaaXp7dC5HSObmgbnR2RN+Un1p68Mf5Q==}
-    dependencies:
-      '@types/web-bluetooth': 0.0.17
-      '@vueuse/metadata': 10.3.0
-      '@vueuse/shared': 10.3.0(vue@3.3.4)
-      vue-demi: 0.14.5(vue@3.3.4)
-    transitivePeerDependencies:
-      - '@vue/composition-api'
-      - vue
-    dev: true
+  '@vueuse/core@12.8.2':
+    resolution: {integrity: sha512-HbvCmZdzAu3VGi/pWYm5Ut+Kd9mn1ZHnn4L5G8kOQTPs/IwIAmJoBrmYk2ckLArgMXZj0AW3n5CAejLUO+PhdQ==}
 
-  /@vueuse/integrations@10.3.0(focus-trap@7.5.2)(vue@3.3.4):
-    resolution: {integrity: sha512-Jgiv7oFyIgC6BxmDtiyG/fxyGysIds00YaY7sefwbhCZ2/tjEx1W/1WcsISSJPNI30in28+HC2J4uuU8184ekg==}
+  '@vueuse/integrations@12.8.2':
+    resolution: {integrity: sha512-fbGYivgK5uBTRt7p5F3zy6VrETlV9RtZjBqd1/HxGdjdckBgBM4ugP8LHpjolqTj14TXTxSK1ZfgPbHYyGuH7g==}
     peerDependencies:
-      async-validator: '*'
-      axios: '*'
-      change-case: '*'
-      drauu: '*'
-      focus-trap: '*'
-      fuse.js: '*'
-      idb-keyval: '*'
-      jwt-decode: '*'
-      nprogress: '*'
-      qrcode: '*'
-      sortablejs: '*'
-      universal-cookie: '*'
+      async-validator: ^4
+      axios: ^1
+      change-case: ^5
+      drauu: ^0.4
+      focus-trap: ^7
+      fuse.js: ^7
+      idb-keyval: ^6
+      jwt-decode: ^4
+      nprogress: ^0.2
+      qrcode: ^1.5
+      sortablejs: ^1
+      universal-cookie: ^7
     peerDependenciesMeta:
       async-validator:
         optional: true
@@ -590,194 +575,261 @@ packages:
         optional: true
       universal-cookie:
         optional: true
-    dependencies:
-      '@vueuse/core': 10.3.0(vue@3.3.4)
-      '@vueuse/shared': 10.3.0(vue@3.3.4)
-      focus-trap: 7.5.2
-      vue-demi: 0.14.5(vue@3.3.4)
-    transitivePeerDependencies:
-      - '@vue/composition-api'
-      - vue
-    dev: true
 
-  /@vueuse/metadata@10.3.0:
-    resolution: {integrity: sha512-Ema3YhNOa4swDsV0V7CEY5JXvK19JI/o1szFO1iWxdFg3vhdFtCtSTP26PCvbUpnUtNHBY2wx5y3WDXND5Pvnw==}
-    dev: true
+  '@vueuse/metadata@12.8.2':
+    resolution: {integrity: sha512-rAyLGEuoBJ/Il5AmFHiziCPdQzRt88VxR+Y/A/QhJ1EWtWqPBBAxTAFaSkviwEuOEZNtW8pvkPgoCZQ+HxqW1A==}
 
-  /@vueuse/shared@10.3.0(vue@3.3.4):
-    resolution: {integrity: sha512-kGqCTEuFPMK4+fNWy6dUOiYmxGcUbtznMwBZLC1PubidF4VZY05B+Oht7Jh7/6x4VOWGpvu3R37WHi81cKpiqg==}
-    dependencies:
-      vue-demi: 0.14.5(vue@3.3.4)
-    transitivePeerDependencies:
-      - '@vue/composition-api'
-      - vue
-    dev: true
+  '@vueuse/shared@12.8.2':
+    resolution: {integrity: sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w==}
 
-  /algoliasearch@4.17.0:
-    resolution: {integrity: sha512-JMRh2Mw6sEnVMiz6+APsi7lx9a2jiDFF+WUtANaUVCv6uSU9UOLdo5h9K3pdP6frRRybaM2fX8b1u0nqICS9aA==}
-    dependencies:
-      '@algolia/cache-browser-local-storage': 4.17.0
-      '@algolia/cache-common': 4.17.0
-      '@algolia/cache-in-memory': 4.17.0
-      '@algolia/client-account': 4.17.0
-      '@algolia/client-analytics': 4.17.0
-      '@algolia/client-common': 4.17.0
-      '@algolia/client-personalization': 4.17.0
-      '@algolia/client-search': 4.17.0
-      '@algolia/logger-common': 4.17.0
-      '@algolia/logger-console': 4.17.0
-      '@algolia/requester-browser-xhr': 4.17.0
-      '@algolia/requester-common': 4.17.0
-      '@algolia/requester-node-http': 4.17.0
-      '@algolia/transporter': 4.17.0
-    dev: true
+  algoliasearch@5.49.0:
+    resolution: {integrity: sha512-Tse7vx7WOvbU+kpq/L3BrBhSWTPbtMa59zIEhMn+Z2NoxZlpcCRUDCRxQ7kDFs1T3CHxDgvb+mDuILiBBpBaAA==}
+    engines: {node: '>= 14.0.0'}
 
-  /ansi-sequence-parser@1.1.0:
-    resolution: {integrity: sha512-lEm8mt52to2fT8GhciPCGeCXACSz2UwIN4X2e2LJSnZ5uAbn2/dsYdOmUXq0AtWS5cpAupysIneExOgH0Vd2TQ==}
-    dev: true
+  balanced-match@4.0.3:
+    resolution: {integrity: sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==}
+    engines: {node: 20 || >=22}
 
-  /body-scroll-lock@4.0.0-beta.0:
-    resolution: {integrity: sha512-a7tP5+0Mw3YlUJcGAKUqIBkYYGlYxk2fnCasq/FUph1hadxlTRjF+gAcZksxANnaMnALjxEddmSi/H3OR8ugcQ==}
-    dev: true
+  birpc@2.9.0:
+    resolution: {integrity: sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==}
 
-  /csstype@3.1.2:
-    resolution: {integrity: sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==}
-    dev: true
+  brace-expansion@5.0.2:
+    resolution: {integrity: sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==}
+    engines: {node: 20 || >=22}
 
-  /esbuild@0.18.16:
-    resolution: {integrity: sha512-1xLsOXrDqwdHxyXb/x/SOyg59jpf/SH7YMvU5RNSU7z3TInaASNJWNFJ6iRvLvLETZMasF3d1DdZLg7sgRimRQ==}
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+
+  code-block-writer@13.0.3:
+    resolution: {integrity: sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==}
+
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
+
+  copy-anything@4.0.5:
+    resolution: {integrity: sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==}
+    engines: {node: '>=18'}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+
+  emoji-regex-xs@1.0.0:
+    resolution: {integrity: sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
     engines: {node: '>=12'}
     hasBin: true
-    requiresBuild: true
-    optionalDependencies:
-      '@esbuild/android-arm': 0.18.16
-      '@esbuild/android-arm64': 0.18.16
-      '@esbuild/android-x64': 0.18.16
-      '@esbuild/darwin-arm64': 0.18.16
-      '@esbuild/darwin-x64': 0.18.16
-      '@esbuild/freebsd-arm64': 0.18.16
-      '@esbuild/freebsd-x64': 0.18.16
-      '@esbuild/linux-arm': 0.18.16
-      '@esbuild/linux-arm64': 0.18.16
-      '@esbuild/linux-ia32': 0.18.16
-      '@esbuild/linux-loong64': 0.18.16
-      '@esbuild/linux-mips64el': 0.18.16
-      '@esbuild/linux-ppc64': 0.18.16
-      '@esbuild/linux-riscv64': 0.18.16
-      '@esbuild/linux-s390x': 0.18.16
-      '@esbuild/linux-x64': 0.18.16
-      '@esbuild/netbsd-x64': 0.18.16
-      '@esbuild/openbsd-x64': 0.18.16
-      '@esbuild/sunos-x64': 0.18.16
-      '@esbuild/win32-arm64': 0.18.16
-      '@esbuild/win32-ia32': 0.18.16
-      '@esbuild/win32-x64': 0.18.16
-    dev: true
 
-  /estree-walker@2.0.2:
+  estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
-    dev: true
 
-  /focus-trap@7.5.2:
-    resolution: {integrity: sha512-p6vGNNWLDGwJCiEjkSK6oERj/hEyI9ITsSwIUICBoKLlWiTWXJRfQibCwcoi50rTZdbi87qDtUlMCmQwsGSgPw==}
-    dependencies:
-      tabbable: 6.2.0
-    dev: true
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
 
-  /fsevents@2.3.2:
-    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+  focus-trap@7.8.0:
+    resolution: {integrity: sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /jsonc-parser@3.2.0:
-    resolution: {integrity: sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==}
-    dev: true
+  hast-util-to-html@9.0.5:
+    resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
 
-  /magic-string@0.30.1:
-    resolution: {integrity: sha512-mbVKXPmS0z0G4XqFDCTllmDQ6coZzn94aMlb0o/A4HEHJCKcanlDZwYJgwnkmgD3jyWhUgj9VsPrfd972yPffA==}
-    engines: {node: '>=12'}
-    dependencies:
-      '@jridgewell/sourcemap-codec': 1.4.15
-    dev: true
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
 
-  /mark.js@8.11.1:
+  hookable@5.5.3:
+    resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
+
+  html-void-elements@3.0.0:
+    resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
+
+  is-what@5.5.0:
+    resolution: {integrity: sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==}
+    engines: {node: '>=18'}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  mark.js@8.11.1:
     resolution: {integrity: sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==}
-    dev: true
 
-  /minisearch@6.1.0:
-    resolution: {integrity: sha512-PNxA/X8pWk+TiqPbsoIYH0GQ5Di7m6326/lwU/S4mlo4wGQddIcf/V//1f9TB0V4j59b57b+HZxt8h3iMROGvg==}
-    dev: true
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
 
-  /nanoid@3.3.6:
-    resolution: {integrity: sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==}
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  minimatch@10.2.2:
+    resolution: {integrity: sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==}
+    engines: {node: 18 || 20 || >=22}
+
+  minisearch@7.2.0:
+    resolution: {integrity: sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==}
+
+  mitt@3.0.1:
+    resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
-    dev: true
 
-  /nprogress@0.2.0:
+  nprogress@0.2.0:
     resolution: {integrity: sha512-I19aIingLgR1fmhftnbWWO3dXc0hSxqHQHQb3H8m+K3TnEn/iSeTZZOyvKXWqQESMwuUVnatlCnZdLBZZt2VSA==}
-    dev: true
 
-  /picocolors@1.0.0:
-    resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
-    dev: true
+  oniguruma-to-es@3.1.1:
+    resolution: {integrity: sha512-bUH8SDvPkH3ho3dvwJwfonjlQ4R80vjyvrU8YpxuROddv55vAEJrTuCuCVUhhsHbtlD9tGGbaNApGQckXhS8iQ==}
 
-  /postcss@8.4.27:
-    resolution: {integrity: sha512-gY/ACJtJPSmUFPDCHtX78+01fHa64FaU4zaaWfuh1MhGJISufJAH4cun6k/8fwsHYeK4UQmENQK+tRLCFJE8JQ==}
+  path-browserify@1.0.1:
+    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
+
+  perfect-debounce@1.0.0:
+    resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.3:
+    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.6:
+    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
-    dependencies:
-      nanoid: 3.3.6
-      picocolors: 1.0.0
-      source-map-js: 1.0.2
-    dev: true
 
-  /preact@10.13.2:
-    resolution: {integrity: sha512-q44QFLhOhty2Bd0Y46fnYW0gD/cbVM9dUVtNTDKPcdXSMA7jfY+Jpd6rk3GB0lcQss0z5s/6CmVP0Z/hV+g6pw==}
-    dev: true
+  preact@10.28.4:
+    resolution: {integrity: sha512-uKFfOHWuSNpRFVTnljsCluEFq57OKT+0QdOiQo8XWnQ/pSvg7OpX5eNOejELXJMWy+BwM2nobz0FkvzmnpCNsQ==}
 
-  /rollup@3.28.0:
-    resolution: {integrity: sha512-d7zhvo1OUY2SXSM6pfNjgD5+d0Nz87CUp4mt8l/GgVP3oBsPwzNvSzyu1me6BSG9JIgWNTVcafIXBIyM8yQ3yw==}
-    engines: {node: '>=14.18.0', npm: '>=8.0.0'}
+  property-information@7.1.0:
+    resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
+
+  regex-recursion@6.0.2:
+    resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
+
+  regex-utilities@2.3.0:
+    resolution: {integrity: sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==}
+
+  regex@6.1.0:
+    resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
+
+  rfdc@1.4.1:
+    resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
+
+  rollup@4.58.0:
+    resolution: {integrity: sha512-wbT0mBmWbIvvq8NeEYWWvevvxnOyhKChir47S66WCxw1SXqhw7ssIYejnQEVt7XYQpsj2y8F9PM+Cr3SNEa0gw==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
-    optionalDependencies:
-      fsevents: 2.3.2
-    dev: true
 
-  /shiki@0.14.3:
-    resolution: {integrity: sha512-U3S/a+b0KS+UkTyMjoNojvTgrBHjgp7L6ovhFVZsXmBGnVdQ4K4U9oK0z63w538S91ATngv1vXigHCSWOwnr+g==}
-    dependencies:
-      ansi-sequence-parser: 1.1.0
-      jsonc-parser: 3.2.0
-      vscode-oniguruma: 1.7.0
-      vscode-textmate: 8.0.0
-    dev: true
+  search-insights@2.17.3:
+    resolution: {integrity: sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==}
 
-  /source-map-js@1.0.2:
-    resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
+  shiki@2.5.0:
+    resolution: {integrity: sha512-mI//trrsaiCIPsja5CNfsyNOqgAZUb6VpJA+340toL42UpzQlXpwRV9nch69X6gaUxrr9kaOOa6e3y3uAkGFxQ==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
-  /tabbable@6.2.0:
-    resolution: {integrity: sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==}
-    dev: true
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
-  /to-fast-properties@2.0.0:
-    resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
-    engines: {node: '>=4'}
-    dev: true
+  speakingurl@14.0.1:
+    resolution: {integrity: sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==}
+    engines: {node: '>=0.10.0'}
 
-  /vite@4.4.9(@types/node@18.14.6):
-    resolution: {integrity: sha512-2mbUn2LlUmNASWwSCNSJ/EG2HuSRTnVNaydp6vMCm5VIqJsjMfbIWtbH2kDuwUVW5mMUKKZvGPX/rqeqVvv1XA==}
-    engines: {node: ^14.18.0 || >=16.0.0}
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
+  superjson@2.2.6:
+    resolution: {integrity: sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==}
+    engines: {node: '>=16'}
+
+  tabbable@6.4.0:
+    resolution: {integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==}
+
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
+  ts-morph@27.0.2:
+    resolution: {integrity: sha512-fhUhgeljcrdZ+9DZND1De1029PrE+cMkIP7ooqkLRTrRLTqcki2AstsyJm0vRNbTbVCNJ0idGlbBrfqc7/nA8w==}
+
+  undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
+
+  vite@5.4.21:
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
-      '@types/node': '>= 14'
+      '@types/node': ^18.0.0 || >=20.0.0
       less: '*'
       lightningcss: ^1.21.0
       sass: '*'
+      sass-embedded: '*'
       stylus: '*'
       sugarss: '*'
       terser: ^5.4.0
@@ -790,59 +842,879 @@ packages:
         optional: true
       sass:
         optional: true
+      sass-embedded:
+        optional: true
       stylus:
         optional: true
       sugarss:
         optional: true
       terser:
         optional: true
-    dependencies:
-      '@types/node': 18.14.6
-      esbuild: 0.18.16
-      postcss: 8.4.27
-      rollup: 3.28.0
-    optionalDependencies:
-      fsevents: 2.3.2
-    dev: true
 
-  /vitepress-plugin-nprogress@0.0.4:
+  vitepress-plugin-nprogress@0.0.4:
     resolution: {integrity: sha512-YzW36kBnjuFH91DOFIA5snyBf4WpF/cYfhAiyNefhqif8QQIKGsbpzvI8VN0M8RHLGr9iQyHhF7dQsm//Xf5Hw==}
-    dependencies:
-      nprogress: 0.2.0
-    dev: true
 
-  /vitepress-plugin-tabs@0.2.0(vitepress@1.0.0-rc.4)(vue@3.3.4):
+  vitepress-plugin-tabs@0.2.0:
     resolution: {integrity: sha512-jTdtz4Z5fHllzcDAJaJK/bxE/2PhJSqetFUFgiB7xzw23O4yI+ntJrN+D3oP8XH/0559QUbrYd0K3YLoRaHbAA==}
     peerDependencies:
       vitepress: ^1.0.0-alpha.29
       vue: ^3.2.45
-    dependencies:
-      vitepress: 1.0.0-rc.4(@types/node@18.14.6)
-      vue: 3.3.4
-    dev: true
 
-  /vitepress@1.0.0-rc.4(@types/node@18.14.6):
-    resolution: {integrity: sha512-JCQ89Bm6ECUTnyzyas3JENo00UDJeK8q1SUQyJYou+4Yz5BKEc/F3O21cu++DnUT2zXc0kvQ2Aj4BZCc/nioXQ==}
+  vitepress@1.6.4:
+    resolution: {integrity: sha512-+2ym1/+0VVrbhNyRoFFesVvBvHAVMZMK0rw60E3X/5349M1GuVdKeazuksqopEdvkKwKGs21Q729jX81/bkBJg==}
     hasBin: true
+    peerDependencies:
+      markdown-it-mathjax3: ^4
+      postcss: ^8
+    peerDependenciesMeta:
+      markdown-it-mathjax3:
+        optional: true
+      postcss:
+        optional: true
+
+  vue@3.5.28:
+    resolution: {integrity: sha512-BRdrNfeoccSoIZeIhyPBfvWSLFP4q8J3u8Ju8Ug5vu3LdD+yTM13Sg4sKtljxozbnuMu1NB1X5HBHRYUzFocKg==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
+
+snapshots:
+
+  '@algolia/abtesting@1.15.0':
     dependencies:
-      '@docsearch/css': 3.5.1
-      '@docsearch/js': 3.5.1
-      '@vitejs/plugin-vue': 4.2.3(vite@4.4.9)(vue@3.3.4)
-      '@vue/devtools-api': 6.5.0
-      '@vueuse/core': 10.3.0(vue@3.3.4)
-      '@vueuse/integrations': 10.3.0(focus-trap@7.5.2)(vue@3.3.4)
-      body-scroll-lock: 4.0.0-beta.0
-      focus-trap: 7.5.2
+      '@algolia/client-common': 5.49.0
+      '@algolia/requester-browser-xhr': 5.49.0
+      '@algolia/requester-fetch': 5.49.0
+      '@algolia/requester-node-http': 5.49.0
+
+  '@algolia/autocomplete-core@1.17.7(@algolia/client-search@5.49.0)(algoliasearch@5.49.0)(search-insights@2.17.3)':
+    dependencies:
+      '@algolia/autocomplete-plugin-algolia-insights': 1.17.7(@algolia/client-search@5.49.0)(algoliasearch@5.49.0)(search-insights@2.17.3)
+      '@algolia/autocomplete-shared': 1.17.7(@algolia/client-search@5.49.0)(algoliasearch@5.49.0)
+    transitivePeerDependencies:
+      - '@algolia/client-search'
+      - algoliasearch
+      - search-insights
+
+  '@algolia/autocomplete-plugin-algolia-insights@1.17.7(@algolia/client-search@5.49.0)(algoliasearch@5.49.0)(search-insights@2.17.3)':
+    dependencies:
+      '@algolia/autocomplete-shared': 1.17.7(@algolia/client-search@5.49.0)(algoliasearch@5.49.0)
+      search-insights: 2.17.3
+    transitivePeerDependencies:
+      - '@algolia/client-search'
+      - algoliasearch
+
+  '@algolia/autocomplete-preset-algolia@1.17.7(@algolia/client-search@5.49.0)(algoliasearch@5.49.0)':
+    dependencies:
+      '@algolia/autocomplete-shared': 1.17.7(@algolia/client-search@5.49.0)(algoliasearch@5.49.0)
+      '@algolia/client-search': 5.49.0
+      algoliasearch: 5.49.0
+
+  '@algolia/autocomplete-shared@1.17.7(@algolia/client-search@5.49.0)(algoliasearch@5.49.0)':
+    dependencies:
+      '@algolia/client-search': 5.49.0
+      algoliasearch: 5.49.0
+
+  '@algolia/client-abtesting@5.49.0':
+    dependencies:
+      '@algolia/client-common': 5.49.0
+      '@algolia/requester-browser-xhr': 5.49.0
+      '@algolia/requester-fetch': 5.49.0
+      '@algolia/requester-node-http': 5.49.0
+
+  '@algolia/client-analytics@5.49.0':
+    dependencies:
+      '@algolia/client-common': 5.49.0
+      '@algolia/requester-browser-xhr': 5.49.0
+      '@algolia/requester-fetch': 5.49.0
+      '@algolia/requester-node-http': 5.49.0
+
+  '@algolia/client-common@5.49.0': {}
+
+  '@algolia/client-insights@5.49.0':
+    dependencies:
+      '@algolia/client-common': 5.49.0
+      '@algolia/requester-browser-xhr': 5.49.0
+      '@algolia/requester-fetch': 5.49.0
+      '@algolia/requester-node-http': 5.49.0
+
+  '@algolia/client-personalization@5.49.0':
+    dependencies:
+      '@algolia/client-common': 5.49.0
+      '@algolia/requester-browser-xhr': 5.49.0
+      '@algolia/requester-fetch': 5.49.0
+      '@algolia/requester-node-http': 5.49.0
+
+  '@algolia/client-query-suggestions@5.49.0':
+    dependencies:
+      '@algolia/client-common': 5.49.0
+      '@algolia/requester-browser-xhr': 5.49.0
+      '@algolia/requester-fetch': 5.49.0
+      '@algolia/requester-node-http': 5.49.0
+
+  '@algolia/client-search@5.49.0':
+    dependencies:
+      '@algolia/client-common': 5.49.0
+      '@algolia/requester-browser-xhr': 5.49.0
+      '@algolia/requester-fetch': 5.49.0
+      '@algolia/requester-node-http': 5.49.0
+
+  '@algolia/ingestion@1.49.0':
+    dependencies:
+      '@algolia/client-common': 5.49.0
+      '@algolia/requester-browser-xhr': 5.49.0
+      '@algolia/requester-fetch': 5.49.0
+      '@algolia/requester-node-http': 5.49.0
+
+  '@algolia/monitoring@1.49.0':
+    dependencies:
+      '@algolia/client-common': 5.49.0
+      '@algolia/requester-browser-xhr': 5.49.0
+      '@algolia/requester-fetch': 5.49.0
+      '@algolia/requester-node-http': 5.49.0
+
+  '@algolia/recommend@5.49.0':
+    dependencies:
+      '@algolia/client-common': 5.49.0
+      '@algolia/requester-browser-xhr': 5.49.0
+      '@algolia/requester-fetch': 5.49.0
+      '@algolia/requester-node-http': 5.49.0
+
+  '@algolia/requester-browser-xhr@5.49.0':
+    dependencies:
+      '@algolia/client-common': 5.49.0
+
+  '@algolia/requester-fetch@5.49.0':
+    dependencies:
+      '@algolia/client-common': 5.49.0
+
+  '@algolia/requester-node-http@5.49.0':
+    dependencies:
+      '@algolia/client-common': 5.49.0
+
+  '@babel/helper-string-parser@7.27.1': {}
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/parser@7.29.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@babel/types@7.29.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
+
+  '@docsearch/css@3.8.2': {}
+
+  '@docsearch/js@3.8.2(@algolia/client-search@5.49.0)(search-insights@2.17.3)':
+    dependencies:
+      '@docsearch/react': 3.8.2(@algolia/client-search@5.49.0)(search-insights@2.17.3)
+      preact: 10.28.4
+    transitivePeerDependencies:
+      - '@algolia/client-search'
+      - '@types/react'
+      - react
+      - react-dom
+      - search-insights
+
+  '@docsearch/react@3.8.2(@algolia/client-search@5.49.0)(search-insights@2.17.3)':
+    dependencies:
+      '@algolia/autocomplete-core': 1.17.7(@algolia/client-search@5.49.0)(algoliasearch@5.49.0)(search-insights@2.17.3)
+      '@algolia/autocomplete-preset-algolia': 1.17.7(@algolia/client-search@5.49.0)(algoliasearch@5.49.0)
+      '@docsearch/css': 3.8.2
+      algoliasearch: 5.49.0
+    optionalDependencies:
+      search-insights: 2.17.3
+    transitivePeerDependencies:
+      - '@algolia/client-search'
+
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
+  '@esbuild/android-x64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
+  '@esbuild/linux-x64@0.21.5':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.21.5':
+    optional: true
+
+  '@iconify-json/simple-icons@1.2.71':
+    dependencies:
+      '@iconify/types': 2.0.0
+
+  '@iconify/types@2.0.0': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@rollup/rollup-android-arm-eabi@4.58.0':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.58.0':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.58.0':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.58.0':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.58.0':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.58.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.58.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.58.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.58.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.58.0':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.58.0':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.58.0':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.58.0':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.58.0':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.58.0':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.58.0':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.58.0':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.58.0':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.58.0':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.58.0':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.58.0':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.58.0':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.58.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.58.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.58.0':
+    optional: true
+
+  '@shikijs/core@2.5.0':
+    dependencies:
+      '@shikijs/engine-javascript': 2.5.0
+      '@shikijs/engine-oniguruma': 2.5.0
+      '@shikijs/types': 2.5.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+      hast-util-to-html: 9.0.5
+
+  '@shikijs/engine-javascript@2.5.0':
+    dependencies:
+      '@shikijs/types': 2.5.0
+      '@shikijs/vscode-textmate': 10.0.2
+      oniguruma-to-es: 3.1.1
+
+  '@shikijs/engine-oniguruma@2.5.0':
+    dependencies:
+      '@shikijs/types': 2.5.0
+      '@shikijs/vscode-textmate': 10.0.2
+
+  '@shikijs/langs@2.5.0':
+    dependencies:
+      '@shikijs/types': 2.5.0
+
+  '@shikijs/themes@2.5.0':
+    dependencies:
+      '@shikijs/types': 2.5.0
+
+  '@shikijs/transformers@2.5.0':
+    dependencies:
+      '@shikijs/core': 2.5.0
+      '@shikijs/types': 2.5.0
+
+  '@shikijs/types@2.5.0':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
+  '@shikijs/vscode-textmate@10.0.2': {}
+
+  '@ts-morph/common@0.28.1':
+    dependencies:
+      minimatch: 10.2.2
+      path-browserify: 1.0.1
+      tinyglobby: 0.2.15
+
+  '@types/estree@1.0.8': {}
+
+  '@types/hast@3.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/linkify-it@5.0.0': {}
+
+  '@types/markdown-it@14.1.2':
+    dependencies:
+      '@types/linkify-it': 5.0.0
+      '@types/mdurl': 2.0.0
+
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/mdurl@2.0.0': {}
+
+  '@types/node@18.19.130':
+    dependencies:
+      undici-types: 5.26.5
+
+  '@types/unist@3.0.3': {}
+
+  '@types/web-bluetooth@0.0.21': {}
+
+  '@ungap/structured-clone@1.3.0': {}
+
+  '@vitejs/plugin-vue@5.2.4(vite@5.4.21(@types/node@18.19.130))(vue@3.5.28)':
+    dependencies:
+      vite: 5.4.21(@types/node@18.19.130)
+      vue: 3.5.28
+
+  '@vue/compiler-core@3.5.28':
+    dependencies:
+      '@babel/parser': 7.29.0
+      '@vue/shared': 3.5.28
+      entities: 7.0.1
+      estree-walker: 2.0.2
+      source-map-js: 1.2.1
+
+  '@vue/compiler-dom@3.5.28':
+    dependencies:
+      '@vue/compiler-core': 3.5.28
+      '@vue/shared': 3.5.28
+
+  '@vue/compiler-sfc@3.5.28':
+    dependencies:
+      '@babel/parser': 7.29.0
+      '@vue/compiler-core': 3.5.28
+      '@vue/compiler-dom': 3.5.28
+      '@vue/compiler-ssr': 3.5.28
+      '@vue/shared': 3.5.28
+      estree-walker: 2.0.2
+      magic-string: 0.30.21
+      postcss: 8.5.6
+      source-map-js: 1.2.1
+
+  '@vue/compiler-ssr@3.5.28':
+    dependencies:
+      '@vue/compiler-dom': 3.5.28
+      '@vue/shared': 3.5.28
+
+  '@vue/devtools-api@7.7.9':
+    dependencies:
+      '@vue/devtools-kit': 7.7.9
+
+  '@vue/devtools-kit@7.7.9':
+    dependencies:
+      '@vue/devtools-shared': 7.7.9
+      birpc: 2.9.0
+      hookable: 5.5.3
+      mitt: 3.0.1
+      perfect-debounce: 1.0.0
+      speakingurl: 14.0.1
+      superjson: 2.2.6
+
+  '@vue/devtools-shared@7.7.9':
+    dependencies:
+      rfdc: 1.4.1
+
+  '@vue/reactivity@3.5.28':
+    dependencies:
+      '@vue/shared': 3.5.28
+
+  '@vue/runtime-core@3.5.28':
+    dependencies:
+      '@vue/reactivity': 3.5.28
+      '@vue/shared': 3.5.28
+
+  '@vue/runtime-dom@3.5.28':
+    dependencies:
+      '@vue/reactivity': 3.5.28
+      '@vue/runtime-core': 3.5.28
+      '@vue/shared': 3.5.28
+      csstype: 3.2.3
+
+  '@vue/server-renderer@3.5.28(vue@3.5.28)':
+    dependencies:
+      '@vue/compiler-ssr': 3.5.28
+      '@vue/shared': 3.5.28
+      vue: 3.5.28
+
+  '@vue/shared@3.5.28': {}
+
+  '@vueuse/core@12.8.2':
+    dependencies:
+      '@types/web-bluetooth': 0.0.21
+      '@vueuse/metadata': 12.8.2
+      '@vueuse/shared': 12.8.2
+      vue: 3.5.28
+    transitivePeerDependencies:
+      - typescript
+
+  '@vueuse/integrations@12.8.2(focus-trap@7.8.0)(nprogress@0.2.0)':
+    dependencies:
+      '@vueuse/core': 12.8.2
+      '@vueuse/shared': 12.8.2
+      vue: 3.5.28
+    optionalDependencies:
+      focus-trap: 7.8.0
+      nprogress: 0.2.0
+    transitivePeerDependencies:
+      - typescript
+
+  '@vueuse/metadata@12.8.2': {}
+
+  '@vueuse/shared@12.8.2':
+    dependencies:
+      vue: 3.5.28
+    transitivePeerDependencies:
+      - typescript
+
+  algoliasearch@5.49.0:
+    dependencies:
+      '@algolia/abtesting': 1.15.0
+      '@algolia/client-abtesting': 5.49.0
+      '@algolia/client-analytics': 5.49.0
+      '@algolia/client-common': 5.49.0
+      '@algolia/client-insights': 5.49.0
+      '@algolia/client-personalization': 5.49.0
+      '@algolia/client-query-suggestions': 5.49.0
+      '@algolia/client-search': 5.49.0
+      '@algolia/ingestion': 1.49.0
+      '@algolia/monitoring': 1.49.0
+      '@algolia/recommend': 5.49.0
+      '@algolia/requester-browser-xhr': 5.49.0
+      '@algolia/requester-fetch': 5.49.0
+      '@algolia/requester-node-http': 5.49.0
+
+  balanced-match@4.0.3: {}
+
+  birpc@2.9.0: {}
+
+  brace-expansion@5.0.2:
+    dependencies:
+      balanced-match: 4.0.3
+
+  ccount@2.0.1: {}
+
+  character-entities-html4@2.1.0: {}
+
+  character-entities-legacy@3.0.0: {}
+
+  code-block-writer@13.0.3: {}
+
+  comma-separated-tokens@2.0.3: {}
+
+  copy-anything@4.0.5:
+    dependencies:
+      is-what: 5.5.0
+
+  csstype@3.2.3: {}
+
+  dequal@2.0.3: {}
+
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
+
+  emoji-regex-xs@1.0.0: {}
+
+  entities@7.0.1: {}
+
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
+
+  estree-walker@2.0.2: {}
+
+  fdir@6.5.0(picomatch@4.0.3):
+    optionalDependencies:
+      picomatch: 4.0.3
+
+  focus-trap@7.8.0:
+    dependencies:
+      tabbable: 6.4.0
+
+  fsevents@2.3.3:
+    optional: true
+
+  hast-util-to-html@9.0.5:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      comma-separated-tokens: 2.0.3
+      hast-util-whitespace: 3.0.0
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.1
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      stringify-entities: 4.0.4
+      zwitch: 2.0.4
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
+  hookable@5.5.3: {}
+
+  html-void-elements@3.0.0: {}
+
+  is-what@5.5.0: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  mark.js@8.11.1: {}
+
+  mdast-util-to-hast@13.2.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.0
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
+
+  minimatch@10.2.2:
+    dependencies:
+      brace-expansion: 5.0.2
+
+  minisearch@7.2.0: {}
+
+  mitt@3.0.1: {}
+
+  nanoid@3.3.11: {}
+
+  nprogress@0.2.0: {}
+
+  oniguruma-to-es@3.1.1:
+    dependencies:
+      emoji-regex-xs: 1.0.0
+      regex: 6.1.0
+      regex-recursion: 6.0.2
+
+  path-browserify@1.0.1: {}
+
+  perfect-debounce@1.0.0: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.3: {}
+
+  postcss@8.5.6:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  preact@10.28.4: {}
+
+  property-information@7.1.0: {}
+
+  regex-recursion@6.0.2:
+    dependencies:
+      regex-utilities: 2.3.0
+
+  regex-utilities@2.3.0: {}
+
+  regex@6.1.0:
+    dependencies:
+      regex-utilities: 2.3.0
+
+  rfdc@1.4.1: {}
+
+  rollup@4.58.0:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.58.0
+      '@rollup/rollup-android-arm64': 4.58.0
+      '@rollup/rollup-darwin-arm64': 4.58.0
+      '@rollup/rollup-darwin-x64': 4.58.0
+      '@rollup/rollup-freebsd-arm64': 4.58.0
+      '@rollup/rollup-freebsd-x64': 4.58.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.58.0
+      '@rollup/rollup-linux-arm-musleabihf': 4.58.0
+      '@rollup/rollup-linux-arm64-gnu': 4.58.0
+      '@rollup/rollup-linux-arm64-musl': 4.58.0
+      '@rollup/rollup-linux-loong64-gnu': 4.58.0
+      '@rollup/rollup-linux-loong64-musl': 4.58.0
+      '@rollup/rollup-linux-ppc64-gnu': 4.58.0
+      '@rollup/rollup-linux-ppc64-musl': 4.58.0
+      '@rollup/rollup-linux-riscv64-gnu': 4.58.0
+      '@rollup/rollup-linux-riscv64-musl': 4.58.0
+      '@rollup/rollup-linux-s390x-gnu': 4.58.0
+      '@rollup/rollup-linux-x64-gnu': 4.58.0
+      '@rollup/rollup-linux-x64-musl': 4.58.0
+      '@rollup/rollup-openbsd-x64': 4.58.0
+      '@rollup/rollup-openharmony-arm64': 4.58.0
+      '@rollup/rollup-win32-arm64-msvc': 4.58.0
+      '@rollup/rollup-win32-ia32-msvc': 4.58.0
+      '@rollup/rollup-win32-x64-gnu': 4.58.0
+      '@rollup/rollup-win32-x64-msvc': 4.58.0
+      fsevents: 2.3.3
+
+  search-insights@2.17.3: {}
+
+  shiki@2.5.0:
+    dependencies:
+      '@shikijs/core': 2.5.0
+      '@shikijs/engine-javascript': 2.5.0
+      '@shikijs/engine-oniguruma': 2.5.0
+      '@shikijs/langs': 2.5.0
+      '@shikijs/themes': 2.5.0
+      '@shikijs/types': 2.5.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
+  source-map-js@1.2.1: {}
+
+  space-separated-tokens@2.0.2: {}
+
+  speakingurl@14.0.1: {}
+
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
+
+  superjson@2.2.6:
+    dependencies:
+      copy-anything: 4.0.5
+
+  tabbable@6.4.0: {}
+
+  tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+
+  trim-lines@3.0.1: {}
+
+  ts-morph@27.0.2:
+    dependencies:
+      '@ts-morph/common': 0.28.1
+      code-block-writer: 13.0.3
+
+  undici-types@5.26.5: {}
+
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
+
+  vite@5.4.21(@types/node@18.19.130):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.6
+      rollup: 4.58.0
+    optionalDependencies:
+      '@types/node': 18.19.130
+      fsevents: 2.3.3
+
+  vitepress-plugin-nprogress@0.0.4:
+    dependencies:
+      nprogress: 0.2.0
+
+  vitepress-plugin-tabs@0.2.0(vitepress@1.6.4(@algolia/client-search@5.49.0)(@types/node@18.19.130)(nprogress@0.2.0)(postcss@8.5.6)(search-insights@2.17.3))(vue@3.5.28):
+    dependencies:
+      vitepress: 1.6.4(@algolia/client-search@5.49.0)(@types/node@18.19.130)(nprogress@0.2.0)(postcss@8.5.6)(search-insights@2.17.3)
+      vue: 3.5.28
+
+  vitepress@1.6.4(@algolia/client-search@5.49.0)(@types/node@18.19.130)(nprogress@0.2.0)(postcss@8.5.6)(search-insights@2.17.3):
+    dependencies:
+      '@docsearch/css': 3.8.2
+      '@docsearch/js': 3.8.2(@algolia/client-search@5.49.0)(search-insights@2.17.3)
+      '@iconify-json/simple-icons': 1.2.71
+      '@shikijs/core': 2.5.0
+      '@shikijs/transformers': 2.5.0
+      '@shikijs/types': 2.5.0
+      '@types/markdown-it': 14.1.2
+      '@vitejs/plugin-vue': 5.2.4(vite@5.4.21(@types/node@18.19.130))(vue@3.5.28)
+      '@vue/devtools-api': 7.7.9
+      '@vue/shared': 3.5.28
+      '@vueuse/core': 12.8.2
+      '@vueuse/integrations': 12.8.2(focus-trap@7.8.0)(nprogress@0.2.0)
+      focus-trap: 7.8.0
       mark.js: 8.11.1
-      minisearch: 6.1.0
-      shiki: 0.14.3
-      vite: 4.4.9(@types/node@18.14.6)
-      vue: 3.3.4
+      minisearch: 7.2.0
+      shiki: 2.5.0
+      vite: 5.4.21(@types/node@18.19.130)
+      vue: 3.5.28
+    optionalDependencies:
+      postcss: 8.5.6
     transitivePeerDependencies:
       - '@algolia/client-search'
       - '@types/node'
       - '@types/react'
-      - '@vue/composition-api'
       - async-validator
       - axios
       - change-case
@@ -857,43 +1729,21 @@ packages:
       - react
       - react-dom
       - sass
+      - sass-embedded
       - search-insights
       - sortablejs
       - stylus
       - sugarss
       - terser
+      - typescript
       - universal-cookie
-    dev: true
 
-  /vscode-oniguruma@1.7.0:
-    resolution: {integrity: sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==}
-    dev: true
-
-  /vscode-textmate@8.0.0:
-    resolution: {integrity: sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==}
-    dev: true
-
-  /vue-demi@0.14.5(vue@3.3.4):
-    resolution: {integrity: sha512-o9NUVpl/YlsGJ7t+xuqJKx8EBGf1quRhCiT6D/J0pfwmk9zUwYkC7yrF4SZCe6fETvSM3UNL2edcbYrSyc4QHA==}
-    engines: {node: '>=12'}
-    hasBin: true
-    requiresBuild: true
-    peerDependencies:
-      '@vue/composition-api': ^1.0.0-rc.1
-      vue: ^3.0.0-0 || ^2.6.0
-    peerDependenciesMeta:
-      '@vue/composition-api':
-        optional: true
+  vue@3.5.28:
     dependencies:
-      vue: 3.3.4
-    dev: true
+      '@vue/compiler-dom': 3.5.28
+      '@vue/compiler-sfc': 3.5.28
+      '@vue/runtime-dom': 3.5.28
+      '@vue/server-renderer': 3.5.28(vue@3.5.28)
+      '@vue/shared': 3.5.28
 
-  /vue@3.3.4:
-    resolution: {integrity: sha512-VTyEYn3yvIeY1Py0WaYGZsXnz3y5UnGi62GjVEqvEGPl6nxbOrCXbVOTQWBEJUqAyTUk2uJ5JLVnYJ6ZzGbrSw==}
-    dependencies:
-      '@vue/compiler-dom': 3.3.4
-      '@vue/compiler-sfc': 3.3.4
-      '@vue/runtime-dom': 3.3.4
-      '@vue/server-renderer': 3.3.4(vue@3.3.4)
-      '@vue/shared': 3.3.4
-    dev: true
+  zwitch@2.0.4: {}

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -1,0 +1,1756 @@
+# Pengu Loader - Full Documentation
+
+> Complete documentation for Pengu Loader, a mod loader for the League of Legends Client.
+
+---
+
+# Welcome
+
+## What is Pengu Loader?
+
+<p align=center style="margin: 3rem 0">
+  <img src="/Pengu_Featherknight_144.jpg" />
+</p>
+
+**Pengu Loader** (formerly **League Loader**) is a **plugin loader** designed
+specifically for the **League of Legends Client**.
+
+With Pengu Loader, you can load **JavaScript** plug-ins into the Client as
+dependencies, which can help you personalize the look and feel of the Client,
+load your custom content, add new features, and improve your overall experience.
+It also allows you to build a smarter Client that fits your needs and
+preferences.
+
+Key features:
+
+- Customize League Client with plugins
+- Theme/personalize your Client
+- Support for modern JavaScript features
+- Support for built-in and remote DevTools
+- Easier to work with LCU API
+
+::: tip Fact
+
+Pengu Loader is a part of our "Programming for gamers" mission.
+
+:::
+
+## Why JavaScript?
+
+<p align=center style="margin: 3rem 0">
+  <img src="/features/javascript.png" />
+</p>
+
+**JavaScript** is a versatile and powerful programming language that is widely
+used in web development. It has become the de facto standard for client-side
+scripting on the web, allowing developers to create interactive and dynamic web
+pages.
+
+The main advantage of JavaScript is its compatibility with the League Client Ux,
+which is actually an embedded Chromium web browser. This means that JavaScript
+plugins can be easily integrated into the client and run seamlessly alongside
+the existing client code. In addition, users can leverage the full power of the
+Chrome DevTools to debug and modify their plugins.
+
+In the case of Pengu Loader, JavaScript provides an ideal platform for
+customizing the League of Legends Client. By using JavaScript plugins, users can
+add new functionality, change the look and feel of the client, and even
+integrate web-based technologies into the client interface. Because JavaScript
+is a widely-used language with a large community of developers, there are many
+existing tools and libraries that can be leveraged to enhance the functionality
+of Pengu Loader.
+
+## Our community
+
+- The [Discord server](https://chat.pengu.lol/)
+- The [GitHub repository](https://github.com/PenguLoader/PenguLoader)
+- The [GitHub organization](https://github.com/PenguLoader)
+
+<br>
+
+Now go to the [Installation](./installation) page to get started.
+
+---
+
+# Installation
+
+Follow the steps below to install:
+
+1. Download the
+   [latest release](https://github.com/PenguLoader/PenguLoader/releases/)
+   - There are two versions, the setup EXE and the portable ZIP version
+   - With the ZIP version, you should extract it to a fixed location
+
+2. Run **Pengu Loader**
+3. Click the switch button to activate it
+
+<p align=center>
+  <img src="https://i.imgur.com/Nv6PsNB.png" />
+</p>
+
+4. Launch **League Client** and enjoy
+
+::: tip
+
+After successful activation, you do not need to run the app again, except to
+update it.
+
+:::
+
+## Troubleshooting
+
+- Windows 7 is not tested, but requires .Net Framework 4.5+ installed to run
+- For Windows 8.1/10 clean install, you should install
+  [VC++ 2015-2019](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170)
+  runtime
+- Do not put any files from the tool in the 'League of Legends' or 'Riot Client'
+  folder
+- Before removing the portable version, you must first deactivate it
+
+## Using plugins
+
+You can get more plugins on the [Discord](https://chat.pengu.lol) server, join
+it now. Each plugin will have its own installation instruction.
+
+If you would like to create your own plugins, please check out the
+[JavaScript Plugin](./javascript-plugin).
+
+---
+
+# JavaScript Plugin
+
+Plugin development requires basic knowledge of
+[JavaScript](https://developer.mozilla.org/en-US/docs/Web/JavaScript), and
+[CSS](https://developer.mozilla.org/en-US/docs/Web/CSS) if you want to make a
+theme. It's pretty easy if you're already familiar with web programming.
+
+## Creating a plugin
+
+Suppose your new plugin name is `your-plugin`.
+
+First, you need to create a new folder called `your-plugin` in the **plugins**
+folder (inside the Pengu Loader root folder).
+
+```
+root/
+  |__plugins/
+    |__@default/        <- the default plugin
+      |...
+    |__your-plugin/     <- your new plugin
+      |__index.js       <- plugin entry
+```
+
+Then create a new file called `index.js` in your plugin folder. This index is an
+entry point for your plugin which will be executed when the League Client is
+ready. Now you can open it in any editor and start coding.
+
+::: tip
+
+We recommend that you use modern JavaScript editors such as
+[Visual Studio Code](https://code.visualstudio.com/) to develop your plugins, as
+it supports intellisense, linter and code auto-completion.
+
+:::
+
+Next, just add this line to the index and save it.
+
+```js
+console.log('Hello, League Client!')
+```
+
+::: info
+
+All your code/text files should be saved in UTF-8 encoding (no BOM). If not,
+your plugin won't work as expected.
+
+:::
+
+Then launch your League Client, and when the Client is ready, try pressing
+`Ctrl Shift I` key to open **Chrome DevTools**. Navigate to the **Console** tab
+in the DevTools and scroll to the top, you will see the output message.
+
+```
+Hello, League Client!
+```
+
+## Plugin entry points
+
+
+
+A plugin's entry point is an exported function in the plugin index that is called automatically by the loader.
+The `init` entry should be called before League Client initializes its scripts.
+
+```js
+export function init(context) {
+  // your code here
+}
+```
+- See [`context.rcp`](../runtime-api/rcp) to use RiotClientPlugin hooks from this `context`.
+- See [`context.socket`](../runtime-api/socket.md) to use built-in socket observation.
+
+As of v1.1.0, you no longer need to put your load script in the `load` event of `window`.
+Instead, you can put in the `load` entry, it will be called even after window is loaded.
+
+```js
+export function load() {
+  // your code here
+}
+```
+
+## Plugin templates
+
+To get started with ease, we have already provided base plugins, check it out:
+https://github.com/PenguLoader/PenguLoader/tree/v1.0.5/plugins
+
+## What's next?
+
+🎉 Congratulations! You have completed the beginner tutorial. Follow the next
+pages to get more power out of your plugins.
+
+- [Module System](./module-system) - Learn more about module system
+- [CSS Theme](./css-theme) - Build your theme with CSS
+- [Assets Handling](./asset-handling) - Add custom content to your plugins
+- [LCU Request](./lcu-request) - Some guides helps you to work with LCU
+- [Runtime API](../runtime-api/) - Useful built-in APIs to use in your plugins
+
+---
+
+# CSS Theme
+
+A plugin is considered a **theme** if it aims to to change the default style of
+the League Client, rather than creating helpers for the Client.
+
+## Creating a theme
+
+From your plugin entry, use `import` to add it:
+
+```javascript
+import './theme.css'
+```
+
+This line will append a link tag to body pointing to `theme.css` next to your
+`index.js` .
+
+```
+your-plugin/
+  |__index.js       <- plugin entry
+  |__theme.css      <- your theme
+```
+
+### Changing the default font
+
+The following will import a custom font from
+[Google Fonts](https://fonts.google.com/) and override the default font using
+the `:root` selector and CSS variables.
+
+```css
+/* theme.css */
+@import url('https://fonts.googleapis.com/css2?family=Shantell+Sans&display=swap');
+
+:root {
+  /* override default League font */
+  --font-display: 'Shantell Sans', sans-serif !important;
+  --font-body: 'Shantell Sans', sans-serif !important;
+}
+```
+
+Note that some selectors may no be applied due to the priority, you can force
+them on top of the rules with the `!important` suffix.
+
+To get more CSS variables used by the Client, you should inpsect them using the
+Chrome DevTools. Try hitting the `Ctrl Shift I` key to open it.
+
+## CSS module
+
+When you **import** the theme, your theme becomes a module. Now you can use the
+relative path of `url()` to import assets.
+
+```css
+/* theme.css */
+.some-div {
+  background-image: url(./assets/background.png);
+}
+
+.another-div {
+  background-image: url(./assets/some-image.jpg);
+}
+```
+
+The corresponding plugin structure:
+
+```
+your-plugin/
+  |__assets/
+    |__background.png
+    |__some-image.jpg
+  |__theme.css
+```
+
+## Remote theme
+
+Using remote theme keeps your theme up to date.
+
+The following will inject a stylesheet link tag pointing to your theme from
+https://example.com/theme.css
+
+```javascript
+// index.js
+function addCssLink(url) {
+  const link = document.createElement('link')
+  link.href = url
+  link.type = 'text/css'
+  link.rel = 'stylesheet'
+  document.head.appendChild(link)
+}
+
+window.addEventListener('load', () => {
+  addCssLink('https://example.com/theme.css')
+})
+```
+
+::: info
+
+Your server should respond with MIME type `text/css` .
+
+:::
+
+---
+
+# Module System
+
+Plugin module system is actually the
+[JavaScript module](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules)
+(also known as ES module).
+
+## JS module
+
+As you know, the plugin entry is a single `index.js` file, using multiple files
+makes your code easier to manage.
+
+The following will have two files, `index.js` and `utils.js.` The **index** will
+acquire the **utils** and print out the retrieved value.
+
+```
+your-plugin/
+  |__index.js
+  |__utils.js
+```
+
+::: code-group
+
+```js [index.js]
+// import utils.js using the import statement
+import utils from './utils'
+
+console.log(utils.greeting) // -> hello
+```
+
+```ts [utils.js]
+// export a simple object
+export default {
+  gretting: 'Hello'
+}
+```
+
+:::
+
+### `import`
+
+> Read more at
+> [MDN import statement](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import).
+> Please note that you no need to add the `.js` extension to import path.
+
+### `export`
+
+> Read more at
+> [MDN export statement](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export).
+
+### Dynamic import
+
+The `import` statement is designed to be used in top-level of code. So you
+cannot use it inside functions or some scopes. Dynamic import allows you to load
+your modules dynamically, even inside a function or scope.
+
+```js
+async function load() {
+  const mod = await import('./mod')
+  // do something
+}
+```
+
+> Read more at
+> [MDN import() operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import).
+> Please note that you no need to add the `.js` extension to import path.
+
+### CDN import
+
+For example, importing **axios** from [**Skypack**](https://skypack.dev).
+
+```js
+import axios from 'https://cdn.skypack.dev/axios'
+
+async function testRequest() {
+  const res = await axios.get('https://...')
+  console.log(res.data)
+}
+```
+
+::: info
+
+Some libraries are designed only for NodeJS, they cannot be imported into the
+plugins.
+
+:::
+
+::: tip Recommended CDNs
+
+- [Skypack](https://www.skypack.dev/)
+- [ESM>CDN](https://esm.sh/)
+- [jsDelivr ESM](https://esm.run)
+- [UNPKG](https://unpkg.com/)
+
+:::
+
+Using dynamic import will be useful when the CDN connection is slow.
+
+```js
+import('https://cdn.skypack.dev/axios')
+  .then(async (mod) => {
+    const axios = mod.default
+    // make a request
+  })
+  .catch((err) => {
+    // handle error
+  })
+```
+
+## CSS module
+
+```js
+import './theme.css'
+```
+
+This line will inject a `link` tag into `body` to load your `theme.css`. It's
+equivalent to the legacy way:
+
+```js
+const link = document.createElement('link')
+link.rel = 'stylesheet'
+link.href = '//plugins/your-plugin/theme.css'
+document.body.appendChild(link)
+```
+
+In your CSS module, you can import plugin assets using relative path:
+
+```css
+.some-div {
+  background-image: url(./assets/image.png);
+  /* resolve to //plugins/your-plugin/assets/image.png */ 
+}
+```
+
+## JSON module
+
+Assuming your `config.json` like this:
+
+```json
+{
+  "enabled": true
+}
+```
+
+Let's import it:
+
+```js
+import config from './config.json'
+console.log(config.enabled) // true
+```
+
+You can also change its value, but no change to the JSON file.
+
+```js
+config.enabled = false
+// in other modules that require it
+console.log(config.enabled) // false
+```
+
+## TOML and YAML module
+
+Since v1.1.0, TOML and YAML formats are supported. They are easy to read and
+solve the JSON brackets hell, as well as the trailing comma problem.
+
+```js
+import config from './config.toml'
+console.log('test toml', config)
+```
+
+In the YAML format, both .yaml and .yml file extensions are legal.
+
+```js
+import config from './config.yaml'
+import config2 from './config2.yml'
+```
+
+> Note that the third-party parsers are imported via esm.sh CDN, some restrcited
+> regions may not work. Please report it.
+
+## Importing assets
+
+For updating HTML elements from JS, you can use `import` to get the asset path
+without knowing its full path.
+
+```
+your-plugin/
+  |__assets/
+    |__background.jpg
+  |__index.js
+
+background URL: //plugins/your-plugin/assets/background.jpg
+```
+
+Here is the example code:
+
+```js
+import background from './assets/background.jpg'
+
+function changeBackground() {
+  const div = document.querySelector('some-div')
+  div.style.backgroundImage = `url(${background})`
+  // or with <img>'s src attribute
+  myImg.src = background
+}
+```
+
+You can log the `background` to see its value:
+
+```js
+console.log(background)
+```
+
+With the structure above, you got
+`//plugins/your-plugin/assets/my-background.jpg`.
+
+::: info
+
+Note that asset import supports common image, font and media file types. Other
+unsupported types won't work; you'll need to add the `?url` suffix in the next
+section to get their path.
+
+:::
+
+## Explicit import
+
+You can specific a suffix value as query param to the import URL.
+
+```js
+import content from './my-data.txt?raw'
+// read the file as string
+
+import path from './some-resource?url'
+// get path to the asset
+```
+
+:::info
+
+With `?raw`, your file should be saved in UTF-8 encoding.
+
+:::
+
+---
+
+# Asset Handling
+
+Assets can be other resources such as fonts, images, media, etc. that you use
+from your plugin to load custom content.
+
+## Local assets
+
+### Plugin assets
+
+Each plugin should have its own assets folder to store assets.
+
+For example, with the plugin structure below:
+
+```
+plugins/
+  |__your-plugin/
+    |__assets/            <- assets
+      |__background.png
+      |...
+    |__index.js           <- entry
+    |__theme.css          <- theme
+```
+
+If your plugin folder name is unique and will not change in the future, you can
+use this link to access the `background.png` directly:
+
+```
+//plugins/your-plugin/assets/background.png
+```
+
+We recommend that you use the module system instead.
+
+::: code-group
+
+```js [index.js]
+import background from './assets/background.png'
+
+// usage
+const img = document.getElementById('some-img')
+img.src = background
+```
+
+```css [theme.css]
+/* note that you should
+import this theme.css from your index.js */
+
+.some-div {
+  background-image: url('./assets/background.png');
+}
+```
+
+:::
+
+### Common assets
+
+Since v0.5, we have provided access to local assets via the `//assets/` domain.
+
+Example:
+
+```
+loader/
+  |__assets/
+    |__your-image.png
+    |__your-background.mp4
+    |...
+  |__plugins/
+    |...
+```
+
+```html
+<img src="//assets/your-image.png" />
+<video src="//assets/your-background.mp4"></video>
+```
+
+## Remote assets
+
+### GitHub file hosting
+
+If you prefer to host your assets on GitHub, you should use the **RawGitHack**
+CDN to avoid access restrictions. It also supports GitLab and Bitbucket.
+
+Try it now: https://raw.githack.com/
+
+![](/guide/rawgithack.png)
+
+### Imgur image hosting
+
+Imgur is a great free image hosting service. You can upload your images to the
+Imgur site and retrieve the link.
+
+Try it now: https://imgur.com/
+
+## Optimizing your resources
+
+You should reduce the asset size to optimize your plugin load time.
+
+- JavaScript and CSS code should be minified for production
+- For SVGs, you can use https://github.com/svg/svgo
+- With images, you should convert them to **webp** format
+- With video, you can try to convert to **webm** format
+
+---
+
+# LCU Request
+
+## Making API request
+
+Just use `fetch` to make LCU requests:
+
+```js
+function acceptMatchFound() {
+  fetch('/lol-matchmaking/v1/ready-check/accept', {
+    method: 'POST',
+  })
+}
+```
+
+Note that `fetch` returns a Promise for async context, you should wrap it inside
+an async function.
+
+```js
+async function getSummonerName() {
+  const res = await fetch('/lol-summoner/v1/current-summoner')
+  const data = await res.json()
+  return data['displayName']
+}
+```
+
+With LCDS (RTMP) calls, you can use `URLSearchParams` and `JSON.strigify` to
+construct call parameters.
+
+```js
+async function quitLobby() { // dont know why people call it 'dodge'
+  const params = new URLSearchParams({
+    destination: 'lcdsServiceProxy',
+    method: 'call',
+    args: JSON.stringify(['', 'teambuilder-draft', 'quitV2', '']),
+  })
+  const url = '/lol-login/v1/session/invoke?' + params.toString()
+  await fetch(url, { method: 'POST' })
+}
+```
+
+::: details LCU API docs
+
+- https://lcu.kebs.dev
+- http://www.mingweisamuel.com/lcu-schema/tool/#/
+
+:::
+
+## LCU WebSocket
+
+When the WebSocket is ready, this link tag will appear:
+
+```html
+<link rel="riot:plugins:websocket" href="wss://riot:.../">
+```
+
+Getting its URI with a simple query.
+
+```js
+document.querySelector('link[rel="riot:plugins:websocket"]').href
+```
+
+Here is an example that subscribes to all API calls:
+
+```js
+function subscribe() {
+  const uri = document.querySelector('link[rel="riot:plugins:websocket"]').href
+  const socket = new WebSocket(uri, 'wamp')
+
+  socket.onopen = () => socket.send(JSON.stringify([5, 'OnJsonApiEvent']))
+  socket.onmessage = async (message) => {
+    const data = JSON.parse(message.data)
+    console.log(data)
+    // @todo process data
+  }
+}
+
+window.addEventListener('load', () => {
+  subscribe()
+})
+```
+
+Listening a single API call, e.g `/lol-gameflow/v1/gameflow-phase`.
+
+```js
+const TARGET_API = '/lol-gameflow/v1/gameflow-phase'
+const TARGET_EVENT = TARGET_API.replace(/\//g, '_')
+// OnJsonApiEvent_lol-gameflow_v1_gameflow-phase
+
+socket.send(JSON.stringify([5, 'OnJsonApiEvent' + TARGET_EVENT]))
+```
+
+Send `6` to unsubscribe from a specific API call, or `OnJsonApiEvent` for all.
+
+```js
+socket.send(JSON.stringify([6, '<EventName>']))
+```
+
+::: tip
+
+Since v1.1.0, we have introduced [`context.socket`](../runtime-api/socket) to for easier socket observation.
+
+:::
+
+## Unauthenticated issue
+
+In some cases that the Ux loads faster than the LCU server, many API that
+require authentication will result in wrong value. You need to wait for this to
+be done before you start plugin initialization.
+
+```js
+const delay = (t) => new Promise((r) => setTimeout(r, t))
+
+async function init() {
+  while (!await getSummonerName()) {
+    await delay(500)
+  }
+
+  // continue
+}
+
+window.addEventListener('load', init)
+```
+
+::: tip
+
+You can do it with the WebSocket way.
+
+:::
+
+## RiotClient API
+
+We provided a `riotclient` domain which helps you to make request to RiotClient
+API.
+
+```
+//riotclient/<api>
+https://riotclient/<api>
+```
+
+For example:
+
+```js
+function getAuthStatus() {
+  return fetch('//riotclient/app-command/v1/auth/status')
+    .then((res) => res.json())
+}
+```
+
+::: details RiotClient API docs
+
+- https://riotclient.kebs.dev
+- https://riotclient.nomi.dev
+
+:::
+
+---
+
+# Npm Compatibility
+
+## Using NodeJS project
+
+We strongly recommend that you to use NodeJS project to build your plugins.
+
+With TypeScript or other languages that require transpilation, you need a build
+tool to build them, Webpack, Rollup or Vite is the best choice.
+
+You can also use any front-end library to build custom UI, e.g. React, Preact,
+Vue, Svelte, SolidJS, etc. With front-end tooling, its hot-reload/HMR will help
+you to do faster.
+
+::: info
+
+Note that npm packages those are designed to run only in NodeJS cannot be used
+to build plugins.
+
+:::
+
+::: tip
+
+With the build tool, the output of your bundled assets may have incorrect paths.
+Please refer to the [Asset Handling](./asset-handling) to make correct
+them.
+
+:::
+
+## Example plugins
+
+### Webpack 📦
+
+- [douugdev/league-a-better-client](https://github.com/douugdev/league-a-better-client) -
+  A LCU utilities with HMR + ⚛ Preact + SASS + TypeScript
+
+### Vite ⚡
+
+- [Pengu vite-theme](https://github.com/PenguLoader/PenguLoader/blob/main/plugins/vite-theme) -
+  A simple theme with HMR + SASS + TypeScript
+- [Pengu @default](https://github.com/PenguLoader/PenguLoader/blob/main/plugins/@default) -
+  The default plugin with HMR + SolidJS + SASS + TypeScript
+
+---
+
+# Migration from v0.6
+
+## New plugin project structure
+
+
+
+Since v0.5, we have introduced the `//assets/` domain which supports access to
+resources from the **assets** folder. And now, this folder is only used for
+large-common-unique resources. So every plugin will have its assets and you can
+access them via `//plugins/`.
+
+Since v1.0, the top-level `js` is not executed as a plugin entry point. Stop
+putting your plugin JS files directly into the **plugins** folder. You need to
+create a new folder for your plugin.
+
+```
+plugins/
+  |__your-plugin/
+    |__assets/
+      |...         <- resources
+    |__index.js    <- plugin entry
+    |...           <- other utils
+```
+
+## Removed CommonJS
+
+
+
+In v1.0, we have been removed CommonJS support and switched to ES module. This
+means all scripts from v0.6 that use `require` and `module.exports` will not
+work in the new version.
+
+Please refer to the migration guide below.
+
+### Update your `require()`:
+
+```js
+// before
+const utils = require('./utils')
+
+// after
+import utils from './utils'
+```
+
+```js
+// before
+const { hello } = require('./greeting')
+
+// after
+import { hello } from './greeting'
+```
+
+> Read more at
+> [MDN import statement](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import).
+> Please note that you no need to add the `.js` extension to import path.
+
+### Also update your `module.exports`:
+
+```js
+// before
+module.exports = {
+  greet: () => 'Hello',
+}
+
+// after
+export default {
+  greet: () => 'Hello',
+}
+```
+
+```js
+// before
+module.exports = to_export
+
+// after
+export default to_export
+```
+
+Just `exports.<id>`:
+
+```js
+// before
+exports.data = some_value
+
+// after
+export let data = some_value
+// or with const if data is immutable
+export const data = some_value
+```
+
+This also works with named functions:
+
+```js
+// before
+exports.todo = function () { ... }
+exports.todoAsync = async function () { ... }
+
+// after
+export function todo() { ... }
+export async function todoAsync() { ... }
+```
+
+> Read more at
+> [MDN export statement](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export).
+
+### Dynamic import
+
+`import` statement does not allow you to use it in non-top-level, in functions
+or some scopes, likes `require()` does.
+
+```js
+// before
+function load() {
+  const utils = require('./utils')
+}
+```
+
+Do it with async context:
+
+```js
+// after
+async function load() {
+  const utils = await import('./utils')
+}
+```
+
+Or with Promise's `.then` callback:
+
+```js
+// after
+function load() {
+  import('./utils').then((module) => {
+    const utils = module.default
+    // ...
+  })
+}
+```
+
+In this case above, `import` becomes an async function like. You can also add a
+`.catch` chain to catch module errors.
+
+> Read more at
+> [MDN import() operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import).
+> Please note that you no need to add the `.js` extension to import path.
+
+### JSON and CSS modules
+
+You should refer to the [Module System](./module-system) to handle
+importing them.
+
+---
+
+# FAQs
+
+<p align=center>
+  <img src="https://styles.redditmedia.com/t5_2rfxx/styles/bannerPositionedImage_dcwlivs38oq61.png" />
+</p>
+
+## Can I get banned?
+
+Pengu Loader is totally safe to use.
+
+## Does it affect the in-game?
+
+No.
+
+## Regions support?
+
+Pengu Loader works for all regions, including Tencent server.
+
+## MacOS support?
+
+Coming soon.
+
+## Reloading the Client causes high memory usage?
+
+The League Client is designed for single loading only. If you reload it using
+the Ctrl+Shift+R key or via Chrome DevTools, the Client will reload its
+interface. But there will be mostly old resources, that may cause memory leaks.
+
+## RunDLL error?
+
+Your antivirus ate/blocked the Loader's core DLL.
+
+## Missing runtime?
+
+Try installing the
+[VC++ 2015-2019](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170)
+runtime.
+
+## LeagueClientUx.exe - System Error?
+
+Make sure you have been deactivated the Loader before removing it.
+
+## The Client looks like Discord glass themes?
+
+Check out the
+[Acrylical theme](https://github.com/PrincessAkira/league-launcher-theme/tree/main/Acrylical),
+or some similar themes.
+
+For theme developers, you should use the [Effect API](../runtime-api/effect) in
+your theme.
+
+## Followed the instructions, but the plugin/theme does not work?
+
+If you have been renamed some files, be sure this File Explorer option is
+unchecked, then recheck your file names.
+
+![](https://i.imgur.com/SUFr9Qk.png)
+
+## My v0.6.0 and v1.0.1 did not work?
+
+After LoL patch 13.8, all previous versions will not work anymore due to 64-bit
+Client update. Please download the latest version right now.
+
+---
+
+# Runtime API
+
+These APIs are designed to use inside League Client with Pengu Loader plugin
+runtime.
+
+## window.openDevTools(remote?)
+
+Call this function to open the built-in Chrome DevTools window.
+
+Example:
+
+```js
+window.openDevTools()     // built-in DevTools
+window.openDevTools(true) // remote DevTools
+```
+
+## window.openPluginsFolder(subdir?)
+
+Call this function to open the plugins folder in new File Explorer window.
+
+If `path` is given, it will open the path with respect to the plugins folder.
+
+Example:
+
+```js
+window.openPluginsFolder()
+window.openPluginsFolder("/plugin-demo/config")
+```
+
+## window.reloadClient()
+
+Call this function to reload the Client and ignore caching.
+
+Example:
+
+```js
+window.reloadClient()
+```
+
+## window.restartClient()
+
+Call this function to restart the Client (entire the UX processes).
+
+Example:
+
+```js
+window.restartClient()
+```
+
+## window.getScriptPath()
+
+Call this function get the current script path.
+
+Example:
+
+```js
+// https://plugins/your-plugin/index.js
+window.getScriptPath()
+```
+
+## window.__llver
+
+This property returns the current version of Pengu Loader.
+
+Example:
+
+```js
+console.log(window.__llver) // 0.6.0
+console.log(`You are using Pengu Loader v${window.__llver}`)
+```
+
+::: tip
+
+Since v1.1.0, this property has been deprecated.
+Please use `Pengu.version` instead.
+
+:::
+
+---
+
+# Pengu
+
+This namespace provides information about current Pengu version and its settings.
+
+## Pengu.version
+
+A read-only property that returns the current version of Pengu Loader.
+
+Example:
+
+```js
+console.log(Pengu.version)
+// 1.0.6
+```
+
+## Pengu.superPotato
+
+A boolean value that indicates the **Super Low Spec Mode** is enabled or not.
+
+Example:
+
+```js
+console.log(Pengu.superPotato)
+// true
+```
+
+## Pengu.plugins
+
+An array of plugin entries.
+
+Example:
+
+```js
+console.log(Pengu.plugins)
+// [ '@default/index.js', 'your-plugin/index.js' ]
+```
+
+## Pengu.isMac
+
+A boolean value that indicates whether the current platform is macOS.
+
+Example:
+
+```js
+if (Pengu.isMac) {
+  console.log('Running on macOS')
+}
+```
+
+---
+
+# CommandBar
+
+Since v1.1.0, we bring to you a new Command Bar 
+that can provide access to app-level commands
+and can be used with any navigation pattern.
+
+Let's press `Ctrl + K` to open the Command Bar.
+
+![](https://i.ibb.co/DWmwtSK/image.png)
+
+### Keyboard shortcuts:
+
+- Use arrow `Down` and `Up` to nagivate the selection.
+- Press `Enter` or just click on an action to execute it.
+- Press `ESC` to close the Command Bar.
+
+<br>
+
+To add your custom actions, please use the APIs below.
+
+## CommandBar.addAction(action)
+
+Add a new action item to the Command Bar. It will automatically update even when showing.
+
+#### Params
+- `action`: An object that describes action information with these properties
+
+```ts
+interface Action {
+  id?: string       // (optional) an unique idetifier for the action
+  name: string      // action's name
+  legend?: string   // (optional) action's note/legend or shortcut key
+  tags?: string[]   // (optional) tags or keywords to search
+  icon?: string     // (optional) <svg> HTML tag in string
+  group?: string    // (optional) group name
+  hidden?: boolean  // (optional) hide the action, except for search results
+  perform?: (id?: string) => any  // called when the action is executed 
+}
+```
+
+## CommandBar.show()
+
+Show the Command Bar programmatically if it was hidden.
+
+## CommandBar.update()
+
+Manually trigger the Command Bar to update its items.
+Only use this function if your added actions are not updating.
+
+---
+
+# DataStore
+
+League Client does not store user data on disk, similar to incognito mode in web browsers. This namespace helps you to store user data on disk.
+
+## DataStore.has(key)
+
+This function returns a boolean indicating whether data with the specified key exists or not.
+
+Example:
+
+```js
+console.log(DataStore.has('my_num'))
+console.log(DataStore.has('key-does-not-exist'))
+```
+
+## DataStore.get(key, fallback?)
+
+Retrieve your stored data with a given key. If the key does not exist, it will return `undefined`.
+
+Since **v1.0.5**, you can set fallback value for non-existent keys.
+
+Example:
+
+```js
+console.log(DataStore.get('my_str'))
+// some string
+console.log(DataStore.get('key-does-not-exist'))
+// undefined
+
+console.log(DataStore.get('key-does-not-exist', 1000))
+// 1000
+```
+
+## DataStore.set(key, value)
+
+Call this function to store your data with a given key.
+
+Parameters:
+- `key` (required) Keys should be string or number.
+- `value` (required) Value may be string, number, boolean, null or collection like array and object. Actually, it will be stored as JSON format, so any value like function and runtime object are ignored.
+
+Returns:
+- A boolean value that indicates your key is valid and the data is stored successfully.
+
+Example:
+
+```js
+let my_num = 10
+let my_str = 'hello'
+DataStore.set('my_num', my_num)
+DataStore.set('my_str', my_str)
+```
+
+::: tip Unique keys
+
+You should use unique names for keys, do not use common names, e.g `access_token`, `is_logged`, etc. Other plugins can override your data, you can add prefix to your keys.
+
+:::
+
+## DataStore.remove(key)
+
+This function removes the specified data from storage by key, returns true if the existing key-value pair has been removed.
+
+Example:
+
+```js
+DataStore.remove('some-key')
+DataStore.has('some-key') // -> false
+```
+
+---
+
+# Effect
+
+This namespace supports changing window transparency/translucent effect.
+
+<br>
+
+![](https://user-images.githubusercontent.com/38210249/216951830-b3bb3ce3-7a5f-4e60-8a67-33d0bce799cf.png)
+
+## Effect.apply()
+
+A function that takes the name of the desired effect name and an optional object.
+It returns a boolean indicating whether the effect was successfully applied or not.
+
+Parameters:
+- `name` [required] These effect names above to be applied, in string.
+- `options` [optional] Additional options for the effect, `acrylic`, `unified` and `blurbehind` could have tint color, but `mica` will ignore this options.
+
+This function returns `false` if the effect could not be applied, see the [System compatibility](#system-compatibility) below.
+
+Example:
+
+```js
+// enable acrylic on Windows 10
+Effect.apply('acrylic')
+
+// with a tint color
+Effect.apply('unified', { color: '#4446' })
+
+// mica on windows 11, no options needed
+Effect.apply('mica')
+```
+
+::: info
+
+Tint colors must be in CSS hex color format, e.g. #RGB, #RGBA, #RRGGBB, #RRGGBBAA.
+
+To see transparency effect correctly, you should remove all lowest backgrounds.
+
+:::
+
+## Effect.clear()
+
+A function that clears any currently applied effect, then the Client background will be black.
+Using `Effect.current` after clearing will give you `undefined`.
+
+Example:
+
+```js
+// just clear applied effect, even if nothing applied
+Effect.clear()
+```
+
+## Effect.setTheme(theme)
+
+Set the window theme to light or dark.
+
+![](https://user-images.githubusercontent.com/38210249/216951865-bb9c6676-58ec-4c81-ad96-67e94e91ac22.png)
+
+## System compatibility
+
+<!-- - These effects are currently supported only Windows 7+. -->
+
+- On Windows 7, only the `blurbehind` is supported.
+- On Windows 10, requires build 1703 or higher to use `acrylic`.
+- `mica` and `unified` are only supported on Windows 11, but `unified` can be
+  enabled on Windows 10 without different from `acrylic`.
+
+::: warning
+
+On Windows 10 build **1903** (19H1) and higher, enabling `acrylic/mica/unified` with
+**Transparency effects** (in Personalize -> Color settings) will cause lag when
+moving the Client window.
+
+:::
+
+## Listening for changes
+
+Add a listener which will be triggered when effect changed.
+
+```js
+window.addEventListener('effect-changed', (event) => {
+  console.log(event.detail)
+})
+```
+
+---
+
+# Toast
+
+This namespace is used to push your toast notifications onto the League Client screen.
+
+## Toast.success(message)
+
+Push a simple notification with a success checkmark.
+
+Params:
+- `message` a string to be shown on the notification.
+
+Example:
+
+```ts
+Toast.success('Welcome to my theme!')
+```
+
+## Toast.error(message)
+
+Push a simple notification with a failure icon.
+
+Params:
+- `message` a string to be shown on the notification.
+
+Example:
+
+```ts
+Toast.error('Oops! Something went wrong.')
+```
+
+## Toast.promise(promise, msg)
+
+Push a progress notification and wait for the given promise to complete.
+This function returns the given promise that is helpful for then/catch chain.
+
+Params:
+- `promise` a promise that the progress waits for.
+- `msg` an object with these properties:
+  - `loading` a string message to be shown when the progress starts loading.
+  - `success` a string to be shown when the promise is resolved.
+  - `error` a string to be shown when the promise is rejected.
+
+Example:
+
+```ts
+let myTask = new Promise((resolve, reject) => {
+  // wait for 3s then fulfill randomly
+  setTimeout(() => {
+    if (Math.random() > 0.5)
+      resolve(10)
+    else
+      reject()
+  }, 3000)
+})
+
+Toast.promise(myTask, {
+  loading: 'Working in progress...',
+  success: 'Oh nice! 😎',
+  error: 'OOps! 😥'
+})
+```
+
+---
+
+# rcp
+
+This object provides easy access and hook to the Riot Client Plugin (RCP) system.
+
+Get the `rcp` in your plugin entry:
+
+```js
+export function init(context) {
+  const rcp = context.rcp
+}
+```
+
+Or get it globally via `window` object:
+
+```js
+const rcp = window.rcp
+```
+
+## rcp.preInit(name, callback)
+
+Register a callback that will be triggered before the target plugin loads.
+
+### Params
+- `name` - RCP name, should be prefixed with `rcp-`.
+- `callback` - A function will be triggered before the plugin loads.
+
+You can delay the plugin loads by blocking your async callback.
+
+Example:
+
+```js
+rcp.preInit('rcp-name', (context) => {
+  // do something
+})
+
+rcp.preInit('rcp-name', async () => {
+  // delay 2 seconds
+  await new Promise(r => setTimeout(r, 2000))
+})
+```
+
+::: warning
+
+Do not pre-hook `rcp-fe-commom-libs`. It is used for the plugin loader, so your callbacks sometimes will not triggered.
+
+:::
+
+## rcp.postInit(name, callback, blocking?)
+
+Register a callback that will be triggered after the target plugin is loaded. Gives you an opportunity to access the plugin API.
+
+### Params
+- `name` - RCP name, should be prefixed with `rcp-`.
+- `callback` - A function will be triggered after the plugin is loaded.
+- `blocking` - A boolean value indicating whether this callback will be executed in blocking way. It's `false` by default.
+
+Example:
+
+```js
+rcp.postInit('rcp-name', (api) => {
+  // do something
+  console.log('got rcp-name:', api)
+})
+```
+
+::: tip
+
+`postInit` and `preInit` should be called before the target plugin loads, preferably witin your plugin's `init` entry. So they will not work after the plugin is loaded.
+
+:::
+
+## rcp.whenReady(name)
+
+This function works as same as `postInit` but allows you to get the target plugin asynchronously and also works even after the plugin is loaded.
+
+Example:
+
+```js
+const uikit = await rcp.whenReady('rcp-fe-lol-uikit')
+```
+
+---
+
+# socket
+
+This namespace helps you to observe specific LCU APIs without creating a new WebSocket.
+You cannot get it directly from `window`, instead use the context of the [`init` entry point](../guide/javascript-plugin#plugin-entry-points).
+
+## socket.observe(api, listener)
+
+Subscribe a listener to listen when the given API endpoint get called.
+
+### Params:
+- `api` a string that presents a LCU API endpoint.
+- `listener` a function that gets called with one data param.
+
+### Return value:
+An object with a prop `disconnect` that could be called to disconnect the observer.
+
+Example:
+
+```js
+socket.observe('/lol-matchmaking/v1/ready-check', (data) => {
+  doAcceptReadyCheck()
+})
+```
+
+## socket.disconnect(api, listener)
+
+Disconnect a subscribed listener. The function parameters like the function above.
+
+---
+
+# PluginFS
+
+This API allows plugins to access **their own directory** and perform some basic file operations.
+
+::: warning
+
+**Top-level** plugin is not allowed since they don't own a directory.
+
+This API currently does not support calls in **remote** script.
+
+:::
+
+::: tip
+
+All paths passed into this API are relative to the root directory of your plugin.
+
+:::
+
+## PluginFS.read(path)
+
+Read a file in text mode.
+
+### Params
+- `path` - The path of the file you want to access with respect to the plugin root directory.
+
+### Return value
+A `Promise` of the content string on success.
+A `Promise` of `undefined` on failure.
+
+Example:
+
+```javascript
+PluginFS.read("./index.js").then( content => {
+    console.log(content)
+})
+
+const content = await PluginFs.read("./README.md")
+```
+
+## PluginFS.write(path, content, enableAppendMode?)
+
+Write to a file in text mode.
+
+### Params
+- `path` - The path of the file you want to access with respect to the plugin root directory.
+- `content` - The content string you want to write into.
+- `enableAppendMode` - Append to file if set to `true` or overwrite file if `false`. This is `false` by default.
+
+### Return value
+A `Promise` of a boolean result indicating success or failure.
+
+Example:
+
+```javascript
+// Create test.txt and write "Hello" into it
+PluginFS.write("./test.txt","Hello").then( result => {
+    if(result){
+        // success
+    }else{
+        // fail
+    }
+})
+
+// Appending " World!" to it 
+const result = await PluginFs.write("./test.txt"," World!",true)
+```
+
+::: tip
+
+This API can create a file but can't create a file under a non-existing directory.
+
+:::
+
+## PluginFS.mkdir(path)
+
+Create directories recursively.
+
+### Params
+`path` - The directory path you want to create with respect to the plugin root directory.
+
+### Return Value
+A `Promise` of a boolean result indicating success or failure.
+
+Example:
+
+```javascript
+const bMkdir0 = await PluginFS.mkdir("utils")
+const bMkdir1 = await PluginFS.mkdir("/a/b")
+const bMkdir2 = await PluginFS.mkdir("/a\\c")
+// false because it already exists
+const bMkdir3 = await PluginFS.mkdir("a\\b/")
+```
+
+## PluginFS.stat(path)
+
+Get the status of a file.
+
+### Params
+- `path` - The file path with respect to the plugin root directory.
+
+### Return value
+A `Promise` of `FileStat` or `undefined` depending on success or failure.
+
+Example:
+
+```javascript
+const stat1 = await PluginFS.stat("a/b")
+if(stat1){
+    console.log("it's a directory")
+}
+const stat2 = await PluginFS.stat("a/random.js")
+```
+
+## PluginFS.ls(path)
+
+List files and directories under given path. 
+
+### Params
+- `path` - The directory path with respect to the plugin root directory.
+
+### Return value
+A `Promise` of `Array` of file name strings on success.
+A `Promise` of `undefined` on failure.
+
+## PluginFS.rm(path, recursively?)
+
+Remove file/directories.
+
+Just like `rm` command in Unix-like systems.
+
+### Params
+- `path` - The file/directory path with respect to the plugin root directory.
+- `recursively` - Delete all files/directories under the give path recursively. This is `false` by default.
+
+### Return value
+A `Promise` of a `number` showing how many files and directories is deleted.
+When deleting with `recursively` set to `true`, the number value is sum of deleted `directories` and `files`.
+
+Example:
+
+```javascript
+// 1
+const bRm1 = await PluginFS.rm("./empty-dir")
+// 1
+const bRm2 = await PluginFS.rm("./random-file-under-plugin-root")
+
+// bRm3 == 0 because it's not empty
+const bRm3 = await PluginFS.rm("./non-empty-dir")
+// bRm4 >= 1 with recursively set to true
+const bRm4 = await PluginFS.rm("./non-empty-dir",true)
+```
+
+::: danger
+
+You should know what you are doing when using this.
+
+:::

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,33 @@
+# Pengu Loader
+
+> Pengu Loader - Unleash the power of Customization from your League of Legends Client
+
+Pengu Loader is a mod loader for the League of Legends Client, allowing users to customize the client using JavaScript plugins and CSS themes.
+
+## Docs
+
+
+### Guide
+
+- [Welcome](https://docs.pengu.lol/guide/welcome)
+- [Installation](https://docs.pengu.lol/guide/installation)
+- [JavaScript Plugin](https://docs.pengu.lol/guide/javascript-plugin)
+- [CSS Theme](https://docs.pengu.lol/guide/css-theme)
+- [Module System](https://docs.pengu.lol/guide/module-system)
+- [Asset Handling](https://docs.pengu.lol/guide/asset-handling)
+- [LCU Request](https://docs.pengu.lol/guide/lcu-request)
+- [NPM Compatibility](https://docs.pengu.lol/guide/npm-compatibility)
+- [Migration from v0.6](https://docs.pengu.lol/guide/migration-from-v0-6)
+- [FAQs](https://docs.pengu.lol/guide/faqs)
+
+### Runtime API
+
+- [Runtime API](https://docs.pengu.lol/runtime-api/)
+- [Pengu](https://docs.pengu.lol/runtime-api/pengu)
+- [CommandBar](https://docs.pengu.lol/runtime-api/command-bar)
+- [DataStore](https://docs.pengu.lol/runtime-api/data-store)
+- [Effect](https://docs.pengu.lol/runtime-api/effect)
+- [Toast](https://docs.pengu.lol/runtime-api/toast)
+- [rcp](https://docs.pengu.lol/runtime-api/rcp)
+- [socket](https://docs.pengu.lol/runtime-api/socket)
+- [PluginFS](https://docs.pengu.lol/runtime-api/plugin-fs)

--- a/scripts/generate-api.js
+++ b/scripts/generate-api.js
@@ -1,0 +1,271 @@
+import { Project, SyntaxKind } from 'ts-morph';
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const project = new Project();
+const sourceFile = project.addSourceFileAtPath(path.resolve(__dirname, '../../PenguLoader/plugins/src/types.d.ts'));
+
+function extractJSDoc(node) {
+    const jsDocs = node.getJsDocs();
+    if (jsDocs.length === 0) return null;
+    
+    const jsDoc = jsDocs[0];
+    const description = jsDoc.getDescription().trim();
+    const tags = jsDoc.getTags().map(tag => {
+        let text = tag.getText().replace(`@${tag.getTagName()}`, '').trim();
+        // Remove leading asterisks from each line
+        text = text.split('\n').map(line => line.replace(/^\s*\*\s?/, '')).join('\n').trim();
+        return {
+            tagName: tag.getTagName(),
+            text
+        };
+    });
+    
+    return { description, tags };
+}
+
+function generateMarkdownForWindow() {
+    const windowInterface = sourceFile.getInterfaceOrThrow('Window');
+    
+    let md = `# Runtime API\n\nThese APIs are designed to use inside League Client with Pengu Loader plugin\nruntime.\n\n`;
+    
+    const properties = windowInterface.getProperties();
+    const methods = windowInterface.getMethods();
+    
+    const allMembers = [...properties, ...methods];
+    
+    for (const member of allMembers) {
+        const name = member.getName();
+        // Skip properties that are namespaces like DataStore, CommandBar, etc.
+        if (['DataStore', 'CommandBar', 'Toast', 'Effect', 'Pengu', 'os', 'rcp', 'PluginFS'].includes(name)) continue;
+        
+        const doc = extractJSDoc(member);
+        if (!doc) continue;
+        
+        const isMethod = member.getKind() === SyntaxKind.MethodSignature || member.getKind() === SyntaxKind.PropertySignature && member.getType().getCallSignatures().length > 0;
+        
+        let signature = name;
+        if (isMethod) {
+            const typeNode = member.getTypeNode();
+            if (typeNode && typeNode.getKind() === SyntaxKind.FunctionType) {
+                const params = typeNode.getParameters().map(p => p.getName() + (p.isOptional() ? '?' : '')).join(', ');
+                signature = `${name}(${params})`;
+            } else if (member.getKind() === SyntaxKind.MethodSignature) {
+                const params = member.getParameters().map(p => p.getName() + (p.isOptional() ? '?' : '')).join(', ');
+                signature = `${name}(${params})`;
+            } else {
+                signature = `${name}()`;
+            }
+        }
+        
+        md += `## window.${signature}\n\n`;
+        
+        let typeText = 'string';
+        if (isMethod) {
+            typeText = 'function';
+        } else if (member.getType().isBoolean()) {
+            typeText = 'boolean';
+        } else if (member.getType().isArray()) {
+            typeText = 'string[ ]'; // Simplified for now
+        }
+        md += `<Badge type="info" text="${typeText}" />\n`;
+        
+        const sinceTag = doc.tags.find(t => t.tagName === 'since');
+        if (sinceTag) {
+            md += `<Badge type="tip" text="since ${sinceTag.text}" />\n`;
+        }
+        
+        const deprecatedTag = doc.tags.find(t => t.tagName === 'deprecated');
+        if (deprecatedTag) {
+            md += `<Badge type="warning" text="deprecated" />\n`;
+        }
+        
+        md += `\n${doc.description}\n\n`;
+        
+        const exampleTag = doc.tags.find(t => t.tagName === 'example');
+        if (exampleTag) {
+            md += `Example:\n\n${exampleTag.text}\n\n`;
+        }
+        
+        // Add any remaining text from the description that might be tips/warnings
+        const descriptionLines = doc.description.split('\n');
+        const tipIndex = descriptionLines.findIndex(line => line.trim().startsWith(':::'));
+        if (tipIndex !== -1) {
+            md += `${descriptionLines.slice(tipIndex).join('\n')}\n\n`;
+        }
+    }
+    
+    fs.writeFileSync(path.resolve(__dirname, '../docs/runtime-api/index.md'), md.trim() + '\n');
+    console.log('Generated index.md');
+}
+
+function generateMarkdownForInterface(interfaceName, fileName, title, descriptionText, footerText) {
+    const iface = sourceFile.getInterface(interfaceName);
+    if (!iface) {
+        console.warn(`Interface ${interfaceName} not found.`);
+        return;
+    }
+    
+    let md = `# ${title}\n\n${descriptionText}\n\n`;
+    
+    const properties = iface.getProperties();
+    const methods = iface.getMethods();
+    
+    const allMembers = [...properties, ...methods];
+    
+    for (const member of allMembers) {
+        const name = member.getName();
+        const doc = extractJSDoc(member);
+        if (!doc) continue;
+        
+        const isMethod = member.getKind() === SyntaxKind.MethodSignature || member.getKind() === SyntaxKind.PropertySignature && member.getType().getCallSignatures().length > 0;
+        
+        let signature = name;
+        if (isMethod) {
+            const typeNode = member.getTypeNode();
+            if (typeNode && typeNode.getKind() === SyntaxKind.FunctionType) {
+                const params = typeNode.getParameters().map(p => p.getName() + (p.isOptional() ? '?' : '')).join(', ');
+                signature = `${name}(${params})`;
+            } else if (member.getKind() === SyntaxKind.MethodSignature) {
+                const params = member.getParameters().map(p => p.getName() + (p.isOptional() ? '?' : '')).join(', ');
+                signature = `${name}(${params})`;
+            } else {
+                signature = `${name}()`;
+            }
+        }
+        
+        md += `## ${title}.${signature}\n\n`;
+        
+        let typeText = 'string';
+        if (isMethod) {
+            typeText = 'function';
+        } else if (member.getType().isBoolean()) {
+            typeText = 'boolean';
+        } else if (member.getType().isArray()) {
+            typeText = 'string[ ]'; // Simplified for now
+        }
+        md += `<Badge type="info" text="${typeText}" />\n`;
+        
+        const sinceTag = doc.tags.find(t => t.tagName === 'since');
+        if (sinceTag) {
+            md += `<Badge type="tip" text="since ${sinceTag.text}" />\n`;
+        }
+        
+        const deprecatedTag = doc.tags.find(t => t.tagName === 'deprecated');
+        if (deprecatedTag) {
+            md += `<Badge type="warning" text="deprecated" />\n`;
+        }
+        
+        md += `\n${doc.description}\n\n`;
+        
+        const exampleTag = doc.tags.find(t => t.tagName === 'example');
+        if (exampleTag) {
+            md += `Example:\n\n${exampleTag.text}\n\n`;
+        }
+        
+        const descriptionLines = doc.description.split('\n');
+        const tipIndex = descriptionLines.findIndex(line => line.trim().startsWith(':::'));
+        if (tipIndex !== -1) {
+            md += `${descriptionLines.slice(tipIndex).join('\n')}\n\n`;
+        }
+    }
+    
+    if (footerText) {
+        md += `${footerText}\n\n`;
+    }
+    
+    fs.writeFileSync(path.resolve(__dirname, `../docs/runtime-api/${fileName}`), md.trim() + '\n');
+    console.log(`Generated ${fileName}`);
+}
+
+generateMarkdownForWindow();
+generateMarkdownForInterface('Pengu', 'pengu.md', 'Pengu', 'This namespace provides information about current Pengu version and its settings.');
+generateMarkdownForInterface('CommandBar', 'command-bar.md', 'CommandBar', `Since v1.1.0, we bring to you a new Command Bar 
+that can provide access to app-level commands
+and can be used with any navigation pattern.
+
+Let's press \`Ctrl + K\` to open the Command Bar.
+
+![](https://i.ibb.co/DWmwtSK/image.png)
+
+### Keyboard shortcuts:
+
+- Use arrow \`Down\` and \`Up\` to nagivate the selection.
+- Press \`Enter\` or just click on an action to execute it.
+- Press \`ESC\` to close the Command Bar.
+
+<br>
+
+To add your custom actions, please use the APIs below.`);
+generateMarkdownForInterface('DataStore', 'data-store.md', 'DataStore', 'League Client does not store user data on disk, similar to incognito mode in web browsers. This namespace helps you to store user data on disk.');
+generateMarkdownForInterface('Effect', 'effect.md', 'Effect', `This namespace supports changing window transparency/translucent effect.
+
+<br>
+
+![](https://user-images.githubusercontent.com/38210249/216951830-b3bb3ce3-7a5f-4e60-8a67-33d0bce799cf.png)`,
+`![](https://user-images.githubusercontent.com/38210249/216951865-bb9c6676-58ec-4c81-ad96-67e94e91ac22.png)
+
+## System compatibility
+
+<!-- - These effects are currently supported only Windows 7+. -->
+
+- On Windows 7, only the \`blurbehind\` is supported.
+- On Windows 10, requires build 1703 or higher to use \`acrylic\`.
+- \`mica\` and \`unified\` are only supported on Windows 11, but \`unified\` can be
+  enabled on Windows 10 without different from \`acrylic\`.
+
+::: warning
+
+On Windows 10 build **1903** (19H1) and higher, enabling \`acrylic/mica/unified\` with
+**Transparency effects** (in Personalize -> Color settings) will cause lag when
+moving the Client window.
+
+:::
+
+## Listening for changes
+
+Add a listener which will be triggered when effect changed.
+
+\`\`\`js
+window.addEventListener('effect-changed', (event) => {
+  console.log(event.detail)
+})
+\`\`\``);
+generateMarkdownForInterface('Toast', 'toast.md', 'Toast', 'This namespace is used to push your toast notifications onto the League Client screen.');
+generateMarkdownForInterface('Rcp', 'rcp.md', 'rcp', `This object provides easy access and hook to the Riot Client Plugin (RCP) system.
+
+Get the \`rcp\` in your plugin entry:
+
+\`\`\`js
+export function init(context) {
+  const rcp = context.rcp
+}
+\`\`\`
+
+Or get it globally via \`window\` object:
+
+\`\`\`js
+const rcp = window.rcp
+\`\`\``);
+generateMarkdownForInterface('Socket', 'socket.md', 'socket', `This namespace helps you to observe specific LCU APIs without creating a new WebSocket.
+You cannot get it directly from \`window\`, instead use the context of the [\`init\` entry point](../guide/javascript-plugin#plugin-entry-points).`);
+generateMarkdownForInterface('PluginFS', 'plugin-fs.md', 'PluginFS', `This API allows plugins to access **their own directory** and perform some basic file operations.
+
+::: warning
+
+**Top-level** plugin is not allowed since they don't own a directory.
+
+This API currently does not support calls in **remote** script.
+
+:::
+
+::: tip
+
+All paths passed into this API are relative to the root directory of your plugin.
+
+:::`);

--- a/scripts/generate-llms.js
+++ b/scripts/generate-llms.js
@@ -1,0 +1,99 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const DOCS_DIR = path.resolve(__dirname, '../docs');
+const PUBLIC_DIR = path.resolve(__dirname, '../public');
+const SITE_URL = 'https://docs.pengu.lol';
+
+// All doc pages in logical order
+const pages = [
+  { file: 'guide/welcome.md', title: 'Welcome', section: 'Guide' },
+  { file: 'guide/installation.md', title: 'Installation', section: 'Guide' },
+  { file: 'guide/javascript-plugin.md', title: 'JavaScript Plugin', section: 'Guide' },
+  { file: 'guide/css-theme.md', title: 'CSS Theme', section: 'Guide' },
+  { file: 'guide/module-system.md', title: 'Module System', section: 'Guide' },
+  { file: 'guide/asset-handling.md', title: 'Asset Handling', section: 'Guide' },
+  { file: 'guide/lcu-request.md', title: 'LCU Request', section: 'Guide' },
+  { file: 'guide/npm-compatibility.md', title: 'NPM Compatibility', section: 'Guide' },
+  { file: 'guide/migration-from-v0-6.md', title: 'Migration from v0.6', section: 'Guide' },
+  { file: 'guide/faqs.md', title: 'FAQs', section: 'Guide' },
+  { file: 'runtime-api/index.md', title: 'Runtime API', section: 'Runtime API' },
+  { file: 'runtime-api/pengu.md', title: 'Pengu', section: 'Runtime API' },
+  { file: 'runtime-api/command-bar.md', title: 'CommandBar', section: 'Runtime API' },
+  { file: 'runtime-api/data-store.md', title: 'DataStore', section: 'Runtime API' },
+  { file: 'runtime-api/effect.md', title: 'Effect', section: 'Runtime API' },
+  { file: 'runtime-api/toast.md', title: 'Toast', section: 'Runtime API' },
+  { file: 'runtime-api/rcp.md', title: 'rcp', section: 'Runtime API' },
+  { file: 'runtime-api/socket.md', title: 'socket', section: 'Runtime API' },
+  { file: 'runtime-api/plugin-fs.md', title: 'PluginFS', section: 'Runtime API' },
+];
+
+function fileToUrl(file) {
+  return `${SITE_URL}/${file.replace(/\.md$/, '').replace(/\/index$/, '/')}`;
+}
+
+function stripFrontmatter(content) {
+  return content.replace(/^---[\s\S]*?---\n*/, '');
+}
+
+function stripBadges(content) {
+  return content.replace(/<Badge[^>]*\/>/g, '').replace(/\n{3,}/g, '\n\n');
+}
+
+function generateLlmsTxt() {
+  let txt = `# Pengu Loader
+
+> Pengu Loader - Unleash the power of Customization from your League of Legends Client
+
+Pengu Loader is a mod loader for the League of Legends Client, allowing users to customize the client using JavaScript plugins and CSS themes.
+
+## Docs
+
+`;
+
+  let currentSection = '';
+  for (const page of pages) {
+    if (page.section !== currentSection) {
+      currentSection = page.section;
+      txt += `\n### ${currentSection}\n\n`;
+    }
+    txt += `- [${page.title}](${fileToUrl(page.file)})\n`;
+  }
+
+  fs.writeFileSync(path.join(PUBLIC_DIR, 'llms.txt'), txt.trim() + '\n');
+  console.log('Generated llms.txt');
+}
+
+function generateLlmsFullTxt() {
+  let txt = `# Pengu Loader - Full Documentation
+
+> Complete documentation for Pengu Loader, a mod loader for the League of Legends Client.
+
+`;
+
+  for (const page of pages) {
+    const filePath = path.join(DOCS_DIR, page.file);
+    if (!fs.existsSync(filePath)) {
+      console.warn(`Warning: ${page.file} not found, skipping`);
+      continue;
+    }
+
+    let content = fs.readFileSync(filePath, 'utf-8');
+    content = stripFrontmatter(content);
+    content = stripBadges(content);
+
+    txt += `---\n\n`;
+    txt += content.trim();
+    txt += `\n\n`;
+  }
+
+  fs.writeFileSync(path.join(PUBLIC_DIR, 'llms-full.txt'), txt.trim() + '\n');
+  console.log('Generated llms-full.txt');
+}
+
+generateLlmsTxt();
+generateLlmsFullTxt();


### PR DESCRIPTION
Introduces an auto-generation pipeline that produces all runtime API documentation from JSDoc comments in `types.d.ts`, replacing the manually-written markdown files.

## Changes
- **New**: `scripts/generate-api.js` - ts-morph based generator that reads `types.d.ts` and outputs VitePress-compatible markdown
- **New**: `predev` and `prebuild` scripts in `package.json` to auto-run the generator
- **Updated**: All 9 runtime API markdown files are now auto-generated:
  - `index.md` (window.* globals)
  - `pengu.md`, `command-bar.md`, `data-store.md`, `effect.md`, `toast.md`
  - `rcp.md`, `socket.md`, `plugin-fs.md`
- **Fixed**: 5 incorrect `@since` version badges (verified against git release tags)
- **Added**: `ts-morph` dev dependency

## How it works
1. The generator parses `types.d.ts` from the PenguLoader repo using ts-morph
2. Extracts JSDoc descriptions, `@since`, `@deprecated`, `@example` tags
3. Produces VitePress markdown with proper Badge components and code blocks
4. Runs automatically before `pnpm dev` and `pnpm build`

This means documentation updates now only require editing JSDoc in `types.d.ts` - the docs site regenerates automatically.